### PR TITLE
Save blob to storage

### DIFF
--- a/src/main/java/com/artipie/docker/asto/AstoBlobs.java
+++ b/src/main/java/com/artipie/docker/asto/AstoBlobs.java
@@ -56,6 +56,9 @@ import org.reactivestreams.FlowAdapters;
  *  It should verify that blob data can be stored via ASTO storage
  *  at correct path (see README and SPEC),
  *  and calculate the digest correctly.
+ * @todo #41:30min Refactor this class, make it more readable.
+ *  Put method is overcomplicated right now, try to decompose it,
+ *  move some logic into new classes or methods.
  * @checkstyle ReturnCountCheck (500 lines)
  */
 public final class AstoBlobs implements BlobStore {

--- a/src/main/java/com/artipie/docker/asto/AstoBlobs.java
+++ b/src/main/java/com/artipie/docker/asto/AstoBlobs.java
@@ -25,18 +25,21 @@
 package com.artipie.docker.asto;
 
 import com.artipie.asto.ByteArray;
+import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.docker.BlobStore;
 import com.artipie.docker.Digest;
 import com.artipie.docker.ref.BlobRef;
 import hu.akarnokd.rxjava3.jdk8interop.SingleInterop;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.internal.operators.flowable.FlowableFromPublisher;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -49,10 +52,10 @@ import org.reactivestreams.FlowAdapters;
 /**
  * Asto {@link BlobStore} implementation.
  * @since 1.0
- * @todo #36:30min Continue implementing put operation.
- *  Now it saves incoming blob into temporary file to caclulate it's digest,
- *  but it should be stored at correct blob path which can be calculated from
- *  digest (see README and SPEC files).
+ * @todo #41:30min Implement integration test for this class.
+ *  It should verify that blob data can be stored via ASTO storage
+ *  at correct path (see README and SPEC),
+ *  and calculate the digest correctly.
  * @checkstyle ReturnCountCheck (500 lines)
  */
 public final class AstoBlobs implements BlobStore {
@@ -83,18 +86,17 @@ public final class AstoBlobs implements BlobStore {
     @Override
     @SuppressWarnings("PMD.OnlyOneReturn")
     public CompletableFuture<Digest> put(final Flow.Publisher<Byte> blob) {
-        final MessageDigest digest;
+        final MessageDigest sha;
         try {
-            digest = MessageDigest.getInstance("SHA-256");
+            sha = MessageDigest.getInstance("SHA-256");
         } catch (final NoSuchAlgorithmException err) {
             throw new IllegalStateException("This runtime doesn't have SHA-256 algorithm", err);
         }
+        final Path tmp;
         final FileChannel out;
         try {
-            out = FileChannel.open(
-                Files.createTempFile(this.getClass().getSimpleName(), ".blob.tmp"),
-                StandardOpenOption.WRITE
-            );
+            tmp = Files.createTempFile(this.getClass().getSimpleName(), ".blob.tmp");
+            out = FileChannel.open(tmp, StandardOpenOption.WRITE);
         } catch (final IOException err) {
             return CompletableFuture.failedFuture(err);
         }
@@ -103,7 +105,7 @@ public final class AstoBlobs implements BlobStore {
             .map(buf -> new ByteArray(buf).primitiveBytes())
             .flatMapCompletable(
                 buf -> Completable.mergeArray(
-                    Completable.fromAction(() -> digest.update(buf)),
+                    Completable.fromAction(() -> sha.update(buf)),
                     Completable.fromAction(
                         () -> {
                             final ByteBuffer wrap = ByteBuffer.wrap(buf);
@@ -113,10 +115,20 @@ public final class AstoBlobs implements BlobStore {
                         }
                     )
                 )
-            ).andThen(Single.fromCallable(() -> new HexOf(new BytesOf(digest.digest())).asString()))
+            ).andThen(Single.fromCallable(() -> new HexOf(new BytesOf(sha.digest())).asString()))
             .map(Digest.Sha256::new)
             .cast(Digest.class)
             .doOnTerminate(out::close)
+            .flatMap(
+                digest -> SingleInterop.fromFuture(
+                    this.asto.save(
+                        new Key.From(RegistryRoot.V2, new BlobRef(digest).string(), "data"),
+                        FlowAdapters.toFlowPublisher(
+                            Flowable.fromArray(new ByteArray(Files.readAllBytes(tmp)).boxedBytes())
+                        )
+                    ).thenApply(none -> digest)
+                )
+            ).doOnTerminate(() -> Files.delete(tmp))
             .to(SingleInterop.get()).toCompletableFuture();
     }
 }

--- a/src/main/java/com/artipie/docker/asto/AstoRepo.java
+++ b/src/main/java/com/artipie/docker/asto/AstoRepo.java
@@ -42,11 +42,6 @@ import javax.json.JsonObject;
 public final class AstoRepo implements Repo {
 
     /**
-     * Base repos key.
-     */
-    private static final Key REPO_BASE = new Key.From("docker", "registry", "v2");
-
-    /**
      * Asto storage.
      */
     private final Storage asto;
@@ -67,14 +62,14 @@ public final class AstoRepo implements Repo {
     @Override
     public CompletableFuture<JsonObject> manifest(final RepoName name, final ManifestRef link) {
         final Key key = new Key.From(
-            AstoRepo.REPO_BASE, "repositories", name.value(),
+            RegistryRoot.V2, "repositories", name.value(),
             "_manifests", link.string()
         );
         return this.asto.value(key)
             .thenCompose(pub -> new BytesFlowAs.Text(pub).future())
-            .thenApply(text -> new Digest.FromLink(text))
+            .thenApply(Digest.FromLink::new)
             .thenApply(digest -> new Key.From(new BlobRef(digest), "data"))
-            .thenCompose(blob -> this.asto.value(new Key.From(AstoRepo.REPO_BASE, blob.string())))
+            .thenCompose(blob -> this.asto.value(new Key.From(RegistryRoot.V2, blob.string())))
             .thenCompose(pub -> new BytesFlowAs.JsonObject(pub).future());
     }
 }

--- a/src/main/java/com/artipie/docker/asto/RegistryRoot.java
+++ b/src/main/java/com/artipie/docker/asto/RegistryRoot.java
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.asto;
+
+import com.artipie.asto.Key;
+
+/**
+ * Docker registry root key.
+ * @since 1.0
+ */
+public final class RegistryRoot extends Key.Wrap {
+
+    /**
+     * Registry root key.
+     */
+    public static final RegistryRoot V2 = new RegistryRoot("v2");
+
+    /**
+     * Ctor.
+     * @param version Registry version
+     */
+    private RegistryRoot(final String version) {
+        super(new Key.From("docker", "registry", version));
+    }
+}


### PR DESCRIPTION
#41 - save `tmp` blob to storage and delete `tmp` file after complete in `AstoBlob#put`. Added `RepoRoot` base key and reuse it in `AstoRepo` class.