### PR TITLE
Using bytebuffers instead of bytes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,15 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.9.1</version>
+      <version>0.13.0</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.akarnokd</groupId>
+      <artifactId>rxjava2-jdk8-interop</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,23 +89,6 @@ SOFTWARE.
       <artifactId>javax.json</artifactId>
       <scope>test</scope>
     </dependency>
-    <!--
-      @todo #52:30min Current junit version in parent pom 5.4.x
-       has a bug with TempDir annotation on Windows
-       https://github.com/junit-team/junit5/issues/2046
-       update dependencies in parent pom and remove these explicit
-       dependency versions.
-    -->
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>5.6.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.6.0</version>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,23 @@ SOFTWARE.
       <artifactId>javax.json</artifactId>
       <scope>test</scope>
     </dependency>
+    <!--
+      @todo #52:30min Current junit version in parent pom 5.4.x
+       has a bug with TempDir annotation on Windows
+       https://github.com/junit-team/junit5/issues/2046
+       update dependencies in parent pom and remove these explicit
+       dependency versions.
+    -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.6.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/com/artipie/docker/BlobStore.java
+++ b/src/main/java/com/artipie/docker/BlobStore.java
@@ -24,6 +24,7 @@
 
 package com.artipie.docker;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 
@@ -38,13 +39,13 @@ public interface BlobStore {
      * @param digest Blob digest
      * @return Async publisher output
      */
-    CompletableFuture<Flow.Publisher<Byte>> blob(Digest digest);
+    CompletableFuture<Flow.Publisher<ByteBuffer>> blob(Digest digest);
 
     /**
      * Put data into blob store and calculate its digest.
      * @param blob Data flow
      * @return Future with digest
      */
-    CompletableFuture<Digest> put(Flow.Publisher<Byte> blob);
+    CompletableFuture<Digest> put(Flow.Publisher<ByteBuffer> blob);
 }
 

--- a/src/main/java/com/artipie/docker/asto/AstoRepo.java
+++ b/src/main/java/com/artipie/docker/asto/AstoRepo.java
@@ -77,6 +77,7 @@ public final class AstoRepo implements Repo {
             .thenApply(Digest.FromLink::new)
             .thenApply(digest -> new Key.From(new BlobRef(digest), "data"))
             .thenCompose(blob -> this.asto.value(new Key.From(RegistryRoot.V2, blob.string())))
-            .thenCompose(pub -> new BytesFlowAs.JsonObject(pub).future());
+            .thenCompose(pub -> new BytesFlowAs.JsonObject(pub).future())
+            .thenApply(struct -> struct.asJsonObject());
     }
 }

--- a/src/main/java/com/artipie/docker/misc/BytesFlowAs.java
+++ b/src/main/java/com/artipie/docker/misc/BytesFlowAs.java
@@ -150,7 +150,7 @@ public abstract class BytesFlowAs<T> {
     }
 
     /**
-     * Accumulator for incomiing bytes chunks.
+     * Accumulator for incoming bytes chunks.
      * @param <T> Target type
      * @since 1.0
      */
@@ -235,7 +235,7 @@ public abstract class BytesFlowAs<T> {
         private final PipedOutputStream out;
 
         /**
-         * Function to convert input stream tot target object.
+         * Function to convert input stream to target object.
          */
         private final Function<InputStream, T> func;
 
@@ -243,15 +243,10 @@ public abstract class BytesFlowAs<T> {
          * Ctor.
          * @param func Accumulator function
          */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         StreamAccum(final Function<InputStream, T> func) {
             this.func = func;
             this.out = new PipedOutputStream();
-            try {
-                this.inp = new PipedInputStream(this.out);
-            } catch (final IOException err) {
-                throw new UncheckedIOException(err);
-            }
+            this.inp = StreamAccum.pipedInput(this.out);
         }
 
         @Override
@@ -263,6 +258,19 @@ public abstract class BytesFlowAs<T> {
         public T value() throws IOException {
             this.out.close();
             return this.func.apply(this.inp);
+        }
+
+        /**
+         * Create new piped input stream from output stream.
+         * @param out Pipe output
+         * @return Pipe input
+         */
+        private static PipedInputStream pipedInput(final PipedOutputStream out) {
+            try {
+                return new PipedInputStream(out);
+            } catch (final IOException err) {
+                throw new UncheckedIOException(err);
+            }
         }
     }
 }

--- a/src/test/java/com/artipie/docker/asto/AstoBlobsITCase.java
+++ b/src/test/java/com/artipie/docker/asto/AstoBlobsITCase.java
@@ -33,16 +33,18 @@ import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 import org.reactivestreams.FlowAdapters;
 
 /**
  * Integration test for {@link AstoBlobs}.
  * @since 0.1
- * @todo #43:30min Implement more integration tests for AstoBlobs,
- *  we should check negative cases when put() method fails, e.g. if
- *  failed to write a file on IOException.
+ * @todo #43:30min Fix a bug with RxFile which doesn't allow to delete
+ *  temporary directories annotated with TempDir after tests.
+ *  After fix remove this annotation to enable tests on Windows.
  */
+@DisabledIfSystemProperty(named = "os.name", matches = "Windows.*")
 final class AstoBlobsITCase {
     @Test
     void saveBlobDataAtCorrectPath(@TempDir final Path tmp) throws Exception {

--- a/src/test/java/com/artipie/docker/asto/AstoDockerTest.java
+++ b/src/test/java/com/artipie/docker/asto/AstoDockerTest.java
@@ -24,7 +24,7 @@
 
 package com.artipie.docker.asto;
 
-import com.artipie.asto.FileStorage;
+import com.artipie.asto.fs.FileStorage;
 import com.artipie.docker.RepoName;
 import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/com/artipie/docker/asto/AstoRepoITCase.java
+++ b/src/test/java/com/artipie/docker/asto/AstoRepoITCase.java
@@ -24,7 +24,7 @@
 
 package com.artipie.docker.asto;
 
-import com.artipie.asto.FileStorage;
+import com.artipie.asto.fs.FileStorage;
 import com.artipie.docker.Repo;
 import com.artipie.docker.RepoName;
 import com.artipie.docker.ref.ManifestRef;

--- a/src/test/java/com/artipie/docker/misc/BytesFlowAsTest.java
+++ b/src/test/java/com/artipie/docker/misc/BytesFlowAsTest.java
@@ -23,8 +23,8 @@
  */
 package com.artipie.docker.misc;
 
-import com.artipie.asto.ByteArray;
-import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -45,9 +45,7 @@ final class BytesFlowAsTest {
         MatcherAssert.assertThat(
             new BytesFlowAs.Text(
                 FlowAdapters.toFlowPublisher(
-                    Flowable.fromArray(
-                        new ByteArray(txt.getBytes(StandardCharsets.UTF_8)).boxedBytes()
-                    )
+                    Flowable.fromArray(ByteBuffer.wrap(txt.getBytes(StandardCharsets.UTF_8)))
                 ),
                 StandardCharsets.UTF_8
             ).future().get(),
@@ -64,8 +62,7 @@ final class BytesFlowAsTest {
             new BytesFlowAs.JsonObject(
                 FlowAdapters.toFlowPublisher(
                     Flowable.fromArray(
-                        new ByteArray(json.toString().getBytes(StandardCharsets.UTF_8))
-                            .boxedBytes()
+                        ByteBuffer.wrap(json.toString().getBytes(StandardCharsets.UTF_8))
                     )
                 )
             ).future().get(),


### PR DESCRIPTION
#52 - using `ByteBuffer` flow instead of `Byte` flow. Updated ASTO dependency, fixed all interfaces where needed, updated helper objects and adapters.