### PR TITLE
Updated Repo interface

### DIFF
--- a/src/main/java/com/artipie/docker/Repo.java
+++ b/src/main/java/com/artipie/docker/Repo.java
@@ -50,7 +50,7 @@ public interface Repo {
     /**
      * Resolve docker image manifest file by reference link.
      * @param link Manifest reference link
-     * @return Future with manifest JSON object
+     * @return Flow with manifest data
      */
     Flow.Publisher<ByteBuffer> manifest(ManifestRef link);
 }

--- a/src/main/java/com/artipie/docker/Repo.java
+++ b/src/main/java/com/artipie/docker/Repo.java
@@ -25,8 +25,8 @@
 package com.artipie.docker;
 
 import com.artipie.docker.ref.ManifestRef;
-import java.util.concurrent.CompletableFuture;
-import javax.json.JsonObject;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Flow;
 
 /**
  * Docker repository files and metadata.
@@ -52,5 +52,5 @@ public interface Repo {
      * @param link Manifest reference link
      * @return Future with manifest JSON object
      */
-    CompletableFuture<JsonObject> manifest(ManifestRef link);
+    Flow.Publisher<ByteBuffer> manifest(ManifestRef link);
 }


### PR DESCRIPTION
#57 - change signature of `Repo` interface to use `ByteBuffer` for manifest reading.