### PR TITLE
#54 - Added Tag class and it's usage in ManifestRef

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@ SOFTWARE.
       <artifactId>javax.json</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-platform.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/com/artipie/docker/Tag.java
+++ b/src/main/java/com/artipie/docker/Tag.java
@@ -1,0 +1,85 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.artipie.docker;
+
+import java.util.regex.Pattern;
+
+/**
+ * Docker image tag.
+ * See <a href="https://docs.docker.com/engine/reference/commandline/tag/">docker tag</a>.
+ *
+ * @since 0.1
+ */
+public interface Tag {
+
+    /**
+     * Tag string.
+     *
+     * @return Tag as string.
+     */
+    String value();
+
+    /**
+     * Valid tag name.
+     * Validation rules are the following:
+     * <p>
+     * A tag name must be valid ASCII and may contain
+     * lowercase and uppercase letters, digits, underscores, periods and dashes.
+     * A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
+     * </p>
+     *
+     * @since 0.1
+     */
+    final class Valid implements Tag {
+
+        /**
+         * RegEx tag validation pattern.
+         */
+        private static final Pattern PATTERN =
+            Pattern.compile("^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$");
+
+        /**
+         * Original unvalidated value.
+         */
+        private final String original;
+
+        /**
+         * Ctor.
+         *
+         * @param original Original unvalidated value.
+         */
+        public Valid(final String original) {
+            this.original = original;
+        }
+
+        @Override
+        public String value() {
+            if (!Tag.Valid.PATTERN.matcher(this.original).matches()) {
+                throw new IllegalStateException(String.format("Invalid tag: %s", this.original));
+            }
+            return this.original;
+        }
+    }
+}

--- a/src/main/java/com/artipie/docker/Tag.java
+++ b/src/main/java/com/artipie/docker/Tag.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  * Docker image tag.
  * See <a href="https://docs.docker.com/engine/reference/commandline/tag/">docker tag</a>.
  *
- * @since 0.1
+ * @since 0.2
  */
 public interface Tag {
 

--- a/src/main/java/com/artipie/docker/ref/ManifestRef.java
+++ b/src/main/java/com/artipie/docker/ref/ManifestRef.java
@@ -26,6 +26,7 @@ package com.artipie.docker.ref;
 
 import com.artipie.asto.Key;
 import com.artipie.docker.Digest;
+import com.artipie.docker.Tag;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -56,11 +57,11 @@ public final class ManifestRef implements Key {
 
     /**
      * Manifest link from a tag.
-     * @param tag Name
+     * @param tag Image tag
      */
-    public ManifestRef(final String tag) {
+    public ManifestRef(final Tag tag) {
         this(
-            Arrays.asList("tags", tag, "current/link")
+            Arrays.asList("tags", tag.value(), "current/link")
         );
     }
 

--- a/src/test/java/com/artipie/docker/TagValidTest.java
+++ b/src/test/java/com/artipie/docker/TagValidTest.java
@@ -1,0 +1,68 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for {@link Tag.Valid}.
+ *
+ * @since 0.1
+ */
+class TagValidTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "latest",
+        "1.0",
+        "my-tag",
+        "MY_TAG",
+        "My.Tag.1",
+        "_some_tag",
+        //@checkstyle LineLengthCheck (1 line)
+        "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567"
+    })
+    void shouldGetValueWhenValid(final String original) {
+        final Tag tag = new Tag.Valid(original);
+        MatcherAssert.assertThat(tag.value(), new IsEqual<>(original));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "",
+        "*",
+        "\u00ea",
+        "-my-tag",
+        //@checkstyle LineLengthCheck (1 line)
+        "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678"
+    })
+    void shouldFailToGetValueWhenInvalid(final String original) {
+        final Tag tag = new Tag.Valid(original);
+        Assertions.assertThrows(IllegalStateException.class, tag::value);
+    }
+}

--- a/src/test/java/com/artipie/docker/TagValidTest.java
+++ b/src/test/java/com/artipie/docker/TagValidTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests for {@link Tag.Valid}.
  *
- * @since 0.1
+ * @since 0.2
  */
 class TagValidTest {
 
@@ -48,13 +48,13 @@ class TagValidTest {
         "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567"
     })
     void shouldGetValueWhenValid(final String original) {
-        final Tag tag = new Tag.Valid(original);
-        MatcherAssert.assertThat(tag.value(), new IsEqual<>(original));
+        MatcherAssert.assertThat(new Tag.Valid(original).value(), new IsEqual<>(original));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {
         "",
+        ".0",
         "*",
         "\u00ea",
         "-my-tag",
@@ -62,7 +62,6 @@ class TagValidTest {
         "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678"
     })
     void shouldFailToGetValueWhenInvalid(final String original) {
-        final Tag tag = new Tag.Valid(original);
-        Assertions.assertThrows(IllegalStateException.class, tag::value);
+        Assertions.assertThrows(IllegalStateException.class, () -> new Tag.Valid(original).value());
     }
 }

--- a/src/test/java/com/artipie/docker/asto/AstoRepoITCase.java
+++ b/src/test/java/com/artipie/docker/asto/AstoRepoITCase.java
@@ -29,6 +29,7 @@ import com.artipie.asto.Remaining;
 import com.artipie.asto.fs.FileStorage;
 import com.artipie.docker.Repo;
 import com.artipie.docker.RepoName;
+import com.artipie.docker.Tag;
 import com.artipie.docker.ref.ManifestRef;
 import io.reactivex.Flowable;
 import io.vertx.reactivex.core.Vertx;
@@ -66,7 +67,7 @@ final class AstoRepoITCase {
 
     @Test
     void shouldReadManifest() throws Exception {
-        final Optional<Content> manifest = this.repo.manifest(new ManifestRef("1"))
+        final Optional<Content> manifest = this.repo.manifest(new ManifestRef(new Tag.Valid("1")))
             .toCompletableFuture()
             .get();
         final byte[] content = new Remaining(
@@ -86,7 +87,7 @@ final class AstoRepoITCase {
 
     @Test
     void shouldReadNoManifestIfAbsent() throws Exception {
-        final Optional<Content> manifest = this.repo.manifest(new ManifestRef("2"))
+        final Optional<Content> manifest = this.repo.manifest(new ManifestRef(new Tag.Valid("2")))
             .toCompletableFuture()
             .get();
         MatcherAssert.assertThat(manifest.isPresent(), new IsEqual<>(false));

--- a/src/test/java/com/artipie/docker/ref/ManifestRefTest.java
+++ b/src/test/java/com/artipie/docker/ref/ManifestRefTest.java
@@ -25,6 +25,7 @@
 package com.artipie.docker.ref;
 
 import com.artipie.docker.Digest;
+import com.artipie.docker.Tag;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,7 @@ public final class ManifestRefTest {
     @Test
     void resolvesTagLink() {
         MatcherAssert.assertThat(
-            new ManifestRef("latest").string(),
+            new ManifestRef(new Tag.Valid("latest")).string(),
             Matchers.equalTo("tags/latest/current/link")
         );
     }


### PR DESCRIPTION
Part of issue #54 
Tag is one of important concepts in Docker API and it's validation is required to implement HTTP API properly.