### PR TITLE
#54 - Routing for pull image manifest endpoint

### DIFF
--- a/src/main/java/com/artipie/docker/http/PullImageManifest.java
+++ b/src/main/java/com/artipie/docker/http/PullImageManifest.java
@@ -36,7 +36,7 @@ import org.reactivestreams.Publisher;
  * Slice for pull image manifest endpoint.
  * See <a href="https://docs.docker.com/registry/spec/api/#pulling-an-image">Pulling An Image</a>.
  *
- * @since 0.1
+ * @since 0.2
  */
 final class PullImageManifest implements Slice {
 

--- a/src/main/java/com/artipie/docker/http/PullImageManifest.java
+++ b/src/main/java/com/artipie/docker/http/PullImageManifest.java
@@ -23,40 +23,35 @@
  */
 package com.artipie.docker.http;
 
+import com.artipie.http.Response;
 import com.artipie.http.Slice;
-import com.artipie.http.rq.RqMethod;
-import com.artipie.http.rt.RtRule;
-import com.artipie.http.rt.SliceRoute;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithStatus;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.reactivestreams.Publisher;
 
 /**
- * Slice implementing Docker Registry HTTP API.
- * See <a href="https://docs.docker.com/registry/spec/api/">Docker Registry HTTP API V2</a>.
+ * Slice for pull image manifest endpoint.
+ * See <a href="https://docs.docker.com/registry/spec/api/#pulling-an-image">Pulling An Image</a>.
  *
  * @since 0.1
  */
-public final class DockerSlice extends Slice.Wrap {
+final class PullImageManifest implements Slice {
 
     /**
-     * Ctor.
+     * RegEx pattern for path.
      */
-    public DockerSlice() {
-        super(
-            new SliceRoute(
-                new SliceRoute.Path(
-                    new RtRule.Multiple(
-                        new RtRule.ByPath("/v2/"),
-                        new RtRule.ByMethod(RqMethod.GET)
-                    ),
-                    new VersionCheck()
-                ),
-                new SliceRoute.Path(
-                    new RtRule.Multiple(
-                        new RtRule.ByPath(PullImageManifest.PATH),
-                        new RtRule.ByMethod(RqMethod.GET)
-                    ),
-                    new PullImageManifest()
-                )
-            )
-        );
+    public static final Pattern PATH = Pattern.compile(
+        "^/v2/(?<name>[^/]*)/manifests/(?<reference>.*)$"
+    );
+
+    @Override
+    public Response response(
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body) {
+        return new RsWithStatus(RsStatus.OK);
     }
 }

--- a/src/test/java/com/artipie/docker/http/DockerSlicePullImageManifestTest.java
+++ b/src/test/java/com/artipie/docker/http/DockerSlicePullImageManifestTest.java
@@ -1,0 +1,80 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.http;
+
+import com.artipie.http.Response;
+import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rs.RsStatus;
+import io.reactivex.Flowable;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link DockerSlice}.
+ * Pull image manifest endpoint.
+ *
+ * @since 0.1
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class DockerSlicePullImageManifestTest {
+
+    @Test
+    void shouldReturnManifestByTag() {
+        final DockerSlice slice = new DockerSlice();
+        final Response response = slice.response(
+            new RequestLine("GET", "/v2/test/manifests/1", "HTTP/1.1").toString(),
+            Collections.emptyList(),
+            Flowable.empty()
+        );
+        MatcherAssert.assertThat(
+            response,
+            new RsHasStatus(RsStatus.OK)
+        );
+    }
+
+    @Test
+    void shouldReturnManifestByDigest() {
+        final DockerSlice slice = new DockerSlice();
+        final String digest = String.join(
+            "",
+            "sha256:",
+            "bc647f47b8a2bb36a54371ced35bee9d1d75eb302f9b5a24d9da0ca04a742e85"
+        );
+        final Response response = slice.response(
+            new RequestLine(
+                "GET",
+                String.format("/v2/test/manifests/%s", digest),
+                "HTTP/1.1"
+            ).toString(),
+            Collections.emptyList(),
+            Flowable.empty()
+        );
+        MatcherAssert.assertThat(
+            response,
+            new RsHasStatus(RsStatus.OK)
+        );
+    }
+}

--- a/src/test/java/com/artipie/docker/http/DockerSlicePullImageManifestTest.java
+++ b/src/test/java/com/artipie/docker/http/DockerSlicePullImageManifestTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
  * Tests for {@link DockerSlice}.
  * Pull image manifest endpoint.
  *
- * @since 0.1
+ * @since 0.2
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class DockerSlicePullImageManifestTest {


### PR DESCRIPTION
Part of #54 
Added routing to pull image manifest endpoint, without proper body in response for now.