### PR TITLE
#54 - Changed ManifestRef to be an interface

### DIFF
--- a/src/test/java/com/artipie/docker/asto/AstoRepoITCase.java
+++ b/src/test/java/com/artipie/docker/asto/AstoRepoITCase.java
@@ -67,9 +67,9 @@ final class AstoRepoITCase {
 
     @Test
     void shouldReadManifest() throws Exception {
-        final Optional<Content> manifest = this.repo.manifest(new ManifestRef(new Tag.Valid("1")))
-            .toCompletableFuture()
-            .get();
+        final Optional<Content> manifest = this.repo.manifest(
+            new ManifestRef.FromTag(new Tag.Valid("1"))
+        ).toCompletableFuture().get();
         final byte[] content = new Remaining(
             Flowable.fromPublisher(manifest.get())
                 .toList()
@@ -87,9 +87,9 @@ final class AstoRepoITCase {
 
     @Test
     void shouldReadNoManifestIfAbsent() throws Exception {
-        final Optional<Content> manifest = this.repo.manifest(new ManifestRef(new Tag.Valid("2")))
-            .toCompletableFuture()
-            .get();
+        final Optional<Content> manifest = this.repo.manifest(
+            new ManifestRef.FromTag(new Tag.Valid("2"))
+        ).toCompletableFuture().get();
         MatcherAssert.assertThat(manifest.isPresent(), new IsEqual<>(false));
     }
 }

--- a/src/test/java/com/artipie/docker/ref/ManifestRefTest.java
+++ b/src/test/java/com/artipie/docker/ref/ManifestRefTest.java
@@ -83,7 +83,7 @@ public final class ManifestRefTest {
     @Test
     void resolvesDigestLink() {
         MatcherAssert.assertThat(
-            new ManifestRef(new Digest.Sha256("0000")).string(),
+            new ManifestRef.FromDigest(new Digest.Sha256("0000")).string(),
             Matchers.equalTo("revisions/sha256/0000/link")
         );
     }
@@ -91,7 +91,7 @@ public final class ManifestRefTest {
     @Test
     void resolvesTagLink() {
         MatcherAssert.assertThat(
-            new ManifestRef(new Tag.Valid("latest")).string(),
+            new ManifestRef.FromTag(new Tag.Valid("latest")).string(),
             Matchers.equalTo("tags/latest/current/link")
         );
     }


### PR DESCRIPTION
Part #54 
Had to change ManifestRef to be an interface to avoid changing `Repo#manifest(ManifestRef)` argument to `Key` and have multiple ManifestRef implementations without class inheritance.