### PR TITLE
#54 - Added API version header to version check response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.7.1</version>
+      <version>0.7.3</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/artipie/docker/http/VersionCheck.java
+++ b/src/main/java/com/artipie/docker/http/VersionCheck.java
@@ -29,9 +29,7 @@ import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithHeaders;
 import com.artipie.http.rs.RsWithStatus;
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.Map;
-import org.cactoos.map.MapEntry;
 import org.reactivestreams.Publisher;
 
 /**
@@ -49,9 +47,7 @@ class VersionCheck implements Slice {
     ) {
         return new RsWithHeaders(
             new RsWithStatus(RsStatus.OK),
-            Collections.singleton(
-                new MapEntry<>("Docker-Distribution-API-Version", "registry/2.0")
-            )
+            "Docker-Distribution-API-Version", "registry/2.0"
         );
     }
 }

--- a/src/main/java/com/artipie/docker/http/VersionCheck.java
+++ b/src/main/java/com/artipie/docker/http/VersionCheck.java
@@ -26,9 +26,12 @@ package com.artipie.docker.http;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithHeaders;
 import com.artipie.http.rs.RsWithStatus;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.Map;
+import org.cactoos.map.MapEntry;
 import org.reactivestreams.Publisher;
 
 /**
@@ -40,8 +43,15 @@ import org.reactivestreams.Publisher;
 class VersionCheck implements Slice {
     @Override
     public Response response(
-        final String line, final Iterable<Map.Entry<String, String>> headers,
-        final Publisher<ByteBuffer> body) {
-        return new RsWithStatus(RsStatus.OK);
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body
+    ) {
+        return new RsWithHeaders(
+            new RsWithStatus(RsStatus.OK),
+            Collections.singleton(
+                new MapEntry<>("Docker-Distribution-API-Version", "registry/2.0")
+            )
+        );
     }
 }

--- a/src/test/java/com/artipie/docker/http/DockerSliceVersionCheckTest.java
+++ b/src/test/java/com/artipie/docker/http/DockerSliceVersionCheckTest.java
@@ -26,12 +26,16 @@ package com.artipie.docker.http;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.docker.asto.AstoDocker;
 import com.artipie.http.Response;
+import com.artipie.http.hm.RsHasHeaders;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
+import java.util.Arrays;
 import java.util.Collections;
+import org.cactoos.map.MapEntry;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,6 +43,7 @@ import org.junit.jupiter.api.Test;
  * Version check endpoint.
  *
  * @since 0.1
+ * @checkstyle ClassDataAbstractionCouplingCheck (2 lines)
  */
 class DockerSliceVersionCheckTest {
 
@@ -52,7 +57,14 @@ class DockerSliceVersionCheckTest {
         );
         MatcherAssert.assertThat(
             response,
-            new RsHasStatus(RsStatus.OK)
+            new AllOf<>(
+                Arrays.asList(
+                    new RsHasStatus(RsStatus.OK),
+                    new RsHasHeaders(
+                        new MapEntry<>("Docker-Distribution-API-Version", "registry/2.0")
+                    )
+                )
+            )
         );
     }
 }


### PR DESCRIPTION
Part of #54 
Added "Docker-Distribution-API-Version" header to version check response. It is required for client to know that registry works by 2.0 protocol