### PR TITLE
#54 - Support for absent values when pulling a layer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.7.3</version>
+      <version>0.7.4</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/artipie/docker/BlobStore.java
+++ b/src/main/java/com/artipie/docker/BlobStore.java
@@ -25,6 +25,7 @@
 package com.artipie.docker;
 
 import com.artipie.asto.Content;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -38,7 +39,7 @@ public interface BlobStore {
      * @param digest Blob digest
      * @return Async publisher output
      */
-    CompletableFuture<Content> blob(Digest digest);
+    CompletableFuture<Optional<Content>> blob(Digest digest);
 
     /**
      * Put data into blob store and calculate its digest.

--- a/src/test/java/com/artipie/docker/http/PullLayerTest.java
+++ b/src/test/java/com/artipie/docker/http/PullLayerTest.java
@@ -90,4 +90,23 @@ class PullLayerTest {
             )
         );
     }
+
+    @Test
+    void shouldReturnNotFoundForUnknownDigest() {
+        MatcherAssert.assertThat(
+            this.slice.response(
+                new RequestLine(
+                    "GET",
+                    String.format(
+                        "/v2/test/blobs/%s",
+                        "sha256:0123456789012345678901234567890123456789012345678901234567890123"
+                    ),
+                    "HTTP/1.1"
+                ).toString(),
+                Collections.emptyList(),
+                Flowable.empty()
+            ),
+            new RsHasStatus(RsStatus.NOT_FOUND)
+        );
+    }
 }


### PR DESCRIPTION
Part of #54
Changed AstoBlobs.blob() method to return no content when it is absent.
Pull layer request returns 404 when content is missing.