### PR TITLE
#54 - Added Content-Type header to pull image manifest response

### DIFF
--- a/src/main/java/com/artipie/docker/Repo.java
+++ b/src/main/java/com/artipie/docker/Repo.java
@@ -24,7 +24,7 @@
 
 package com.artipie.docker;
 
-import com.artipie.asto.Content;
+import com.artipie.docker.manifest.Manifest;
 import com.artipie.docker.ref.ManifestRef;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
@@ -53,5 +53,5 @@ public interface Repo {
      * @param ref Manifest reference
      * @return Flow with manifest data, or empty if absent
      */
-    CompletionStage<Optional<Content>> manifest(ManifestRef ref);
+    CompletionStage<Optional<Manifest>> manifest(ManifestRef ref);
 }

--- a/src/main/java/com/artipie/docker/http/PullImageManifest.java
+++ b/src/main/java/com/artipie/docker/http/PullImageManifest.java
@@ -25,15 +25,20 @@ package com.artipie.docker.http;
 
 import com.artipie.docker.Docker;
 import com.artipie.docker.RepoName;
+import com.artipie.docker.manifest.Manifest;
 import com.artipie.docker.ref.ManifestRef;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
 import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithBody;
+import com.artipie.http.rs.RsWithHeaders;
 import com.artipie.http.rs.RsWithStatus;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.reactivestreams.Publisher;
@@ -109,23 +114,30 @@ final class PullImageManifest {
                     String.format("Unexpected path: %s", path)
                 );
             }
-            final String name = matcher.group("name");
+            final RepoName name = new RepoName.Valid(matcher.group("name"));
             final ManifestRef ref = new ManifestRef.FromString(matcher.group("reference"));
-            return connection -> this.docker.repo(new RepoName.Valid(name)).manifest(ref)
-                .thenCompose(
-                    manifest -> {
-                        final Response response;
-                        if (manifest.isPresent()) {
-                            response = new RsWithBody(
-                                new RsWithStatus(RsStatus.OK),
-                                manifest.get()
-                            );
-                        } else {
-                            response = new RsWithStatus(RsStatus.NOT_FOUND);
-                        }
-                        return response.send(connection);
-                    }
-                );
+            return new AsyncResponse(
+                this.docker.repo(name).manifest(ref).thenCompose(
+                    manifest -> manifest.map(Get::response).orElseGet(
+                        () -> CompletableFuture.completedStage(new RsWithStatus(RsStatus.NOT_FOUND))
+                    )
+                )
+            );
+        }
+
+        /**
+         * Create HTTP response from {@link Manifest}.
+         *
+         * @param manifest Manifest.
+         * @return HTTP response.
+         */
+        private static CompletionStage<Response> response(final Manifest manifest) {
+            return manifest.mediaType().thenApply(
+                type -> new RsWithBody(
+                    new RsWithHeaders(new RsWithStatus(RsStatus.OK), "Content-Type", type),
+                    manifest.content()
+                )
+            );
         }
     }
 }

--- a/src/test/java/com/artipie/docker/http/PullImageManifestGetTest.java
+++ b/src/test/java/com/artipie/docker/http/PullImageManifestGetTest.java
@@ -27,6 +27,7 @@ import com.artipie.asto.Key;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.docker.ExampleStorage;
 import com.artipie.docker.asto.AstoDocker;
+import com.artipie.http.Response;
 import com.artipie.http.hm.RsHasBody;
 import com.artipie.http.hm.RsHasHeaders;
 import com.artipie.http.hm.RsHasStatus;
@@ -36,6 +37,7 @@ import io.reactivex.Flowable;
 import java.util.Arrays;
 import java.util.Collections;
 import org.cactoos.map.MapEntry;
+import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,28 +65,16 @@ class PullImageManifestGetTest {
 
     @Test
     void shouldReturnManifestByTag() {
-        final Key expected = new Key.From(
-            "docker", "registry", "v2", "blobs", "sha256", "cb",
-            "cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221", "data"
-        );
         MatcherAssert.assertThat(
             this.slice.response(
                 new RequestLine("GET", "/v2/my-alpine/manifests/1", "HTTP/1.1").toString(),
                 Collections.emptyList(),
                 Flowable.empty()
             ),
-            new AllOf<>(
-                Arrays.asList(
-                    new RsHasStatus(RsStatus.OK),
-                    new RsHasHeaders(
-                        new MapEntry<>(
-                            "Content-Type",
-                            "application/vnd.docker.distribution.manifest.v2+json"
-                        )
-                    ),
-                    new RsHasBody(
-                        new BlockingStorage(new ExampleStorage()).value(expected)
-                    )
+            success(
+                new Key.From(
+                    "docker", "registry", "v2", "blobs", "sha256", "cb",
+                    "cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221", "data"
                 )
             )
         );
@@ -92,10 +82,6 @@ class PullImageManifestGetTest {
 
     @Test
     void shouldReturnManifestByDigest() {
-        final Key expected = new Key.From(
-            "docker", "registry", "v2", "blobs", "sha256", "cb",
-            "cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221", "data"
-        );
         MatcherAssert.assertThat(
             this.slice.response(
                 new RequestLine(
@@ -109,18 +95,10 @@ class PullImageManifestGetTest {
                 Collections.emptyList(),
                 Flowable.empty()
             ),
-            new AllOf<>(
-                Arrays.asList(
-                    new RsHasStatus(RsStatus.OK),
-                    new RsHasHeaders(
-                        new MapEntry<>(
-                            "Content-Type",
-                            "application/vnd.docker.distribution.manifest.v2+json"
-                        )
-                    ),
-                    new RsHasBody(
-                        new BlockingStorage(new ExampleStorage()).value(expected)
-                    )
+            success(
+                new Key.From(
+                    "docker", "registry", "v2", "blobs", "sha256", "cb",
+                    "cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221", "data"
                 )
             )
         );
@@ -154,6 +132,23 @@ class PullImageManifestGetTest {
                 Flowable.empty()
             ),
             new RsHasStatus(RsStatus.NOT_FOUND)
+        );
+    }
+
+    private static Matcher<Response> success(final Key content) {
+        return new AllOf<>(
+            Arrays.asList(
+                new RsHasStatus(RsStatus.OK),
+                new RsHasHeaders(
+                    new MapEntry<>(
+                        "Content-Type",
+                        "application/vnd.docker.distribution.manifest.v2+json"
+                    )
+                ),
+                new RsHasBody(
+                    new BlockingStorage(new ExampleStorage()).value(content)
+                )
+            )
         );
     }
 }

--- a/src/test/java/com/artipie/docker/http/PullImageManifestGetTest.java
+++ b/src/test/java/com/artipie/docker/http/PullImageManifestGetTest.java
@@ -28,12 +28,14 @@ import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.docker.ExampleStorage;
 import com.artipie.docker.asto.AstoDocker;
 import com.artipie.http.hm.RsHasBody;
+import com.artipie.http.hm.RsHasHeaders;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
 import java.util.Arrays;
 import java.util.Collections;
+import org.cactoos.map.MapEntry;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,6 +76,12 @@ class PullImageManifestGetTest {
             new AllOf<>(
                 Arrays.asList(
                     new RsHasStatus(RsStatus.OK),
+                    new RsHasHeaders(
+                        new MapEntry<>(
+                            "Content-Type",
+                            "application/vnd.docker.distribution.manifest.v2+json"
+                        )
+                    ),
                     new RsHasBody(
                         new BlockingStorage(new ExampleStorage()).value(expected)
                     )
@@ -104,6 +112,12 @@ class PullImageManifestGetTest {
             new AllOf<>(
                 Arrays.asList(
                     new RsHasStatus(RsStatus.OK),
+                    new RsHasHeaders(
+                        new MapEntry<>(
+                            "Content-Type",
+                            "application/vnd.docker.distribution.manifest.v2+json"
+                        )
+                    ),
                     new RsHasBody(
                         new BlockingStorage(new ExampleStorage()).value(expected)
                     )


### PR DESCRIPTION
Part of #54 
Response of pull image request now includes Content-Type header as per spec.
`AstoRepo.manifest()` now returns `Manifest`