### PR TITLE
#54 - Added ManifestRef.string() method

### DIFF
--- a/src/main/java/com/artipie/docker/ref/ManifestRef.java
+++ b/src/main/java/com/artipie/docker/ref/ManifestRef.java
@@ -48,6 +48,13 @@ public interface ManifestRef {
     Key link();
 
     /**
+     * String representation.
+     *
+     * @return Reference as string.
+     */
+    String string();
+
+    /**
      * Manifest reference from {@link Digest}.
      *
      * @since 0.2
@@ -73,6 +80,11 @@ public interface ManifestRef {
             return new Key.From(
                 Arrays.asList("revisions", this.digest.alg(), this.digest.hex(), "link")
             );
+        }
+
+        @Override
+        public String string() {
+            return this.digest.string();
         }
     }
 
@@ -102,6 +114,11 @@ public interface ManifestRef {
             return new Key.From(
                 Arrays.asList("tags", this.tag.value(), "current", "link")
             );
+        }
+
+        @Override
+        public String string() {
+            return this.tag.value();
         }
     }
 
@@ -143,6 +160,11 @@ public interface ManifestRef {
                 );
             }
             return ref.link();
+        }
+
+        @Override
+        public String string() {
+            return this.value;
         }
     }
 }

--- a/src/test/java/com/artipie/docker/ref/ManifestRefTest.java
+++ b/src/test/java/com/artipie/docker/ref/ManifestRefTest.java
@@ -95,4 +95,21 @@ public final class ManifestRefTest {
             Matchers.equalTo("tags/latest/current/link")
         );
     }
+
+    @Test
+    void stringFromDigestRef() {
+        MatcherAssert.assertThat(
+            new ManifestRef.FromDigest(new Digest.Sha256("0123")).string(),
+            Matchers.equalTo("sha256:0123")
+        );
+    }
+
+    @Test
+    void stringFromTagRef() {
+        final String tag = "0.2";
+        MatcherAssert.assertThat(
+            new ManifestRef.FromTag(new Tag.Valid(tag)).string(),
+            Matchers.equalTo(tag)
+        );
+    }
 }

--- a/src/test/java/com/artipie/docker/ref/ManifestRefTest.java
+++ b/src/test/java/com/artipie/docker/ref/ManifestRefTest.java
@@ -112,4 +112,13 @@ public final class ManifestRefTest {
             Matchers.equalTo(tag)
         );
     }
+
+    @Test
+    void stringFromStringRef() {
+        final String value = "whatever";
+        MatcherAssert.assertThat(
+            new ManifestRef.FromString(value).string(),
+            Matchers.equalTo(value)
+        );
+    }
 }


### PR DESCRIPTION
Part of #54 
Added method to represent manifest reference as a string. This is required to generate `Location` header when manifest is added to the registry.