### PR TITLE
#54 - Fixed upload offset bug

### DIFF
--- a/src/main/java/com/artipie/docker/asto/AstoUpload.java
+++ b/src/main/java/com/artipie/docker/asto/AstoUpload.java
@@ -79,7 +79,7 @@ public final class AstoUpload implements Upload {
                 return this.storage.save(tmp, new Content.From(chunk)).thenCompose(
                     ignored -> this.storage.move(tmp, this.data())
                 ).thenCompose(
-                    ignored -> this.storage.size(this.data())
+                    ignored -> this.storage.size(this.data()).thenApply(size -> size - 1)
                 );
             }
         );

--- a/src/test/java/com/artipie/docker/asto/AstoUploadTest.java
+++ b/src/test/java/com/artipie/docker/asto/AstoUploadTest.java
@@ -62,6 +62,14 @@ class AstoUploadTest {
     }
 
     @Test
+    void shouldAppendedChunk() {
+        final byte[] chunk = "sample".getBytes();
+        final Long offset = this.upload.append(Flowable.just(ByteBuffer.wrap(chunk)))
+            .toCompletableFuture().join();
+        MatcherAssert.assertThat(offset, new IsEqual<>((long) chunk.length - 1));
+    }
+
+    @Test
     void shouldReadAppendedChunk() throws Exception {
         final byte[] chunk = "chunk".getBytes();
         this.upload.append(Flowable.just(ByteBuffer.wrap(chunk))).toCompletableFuture().join();

--- a/src/test/java/com/artipie/docker/asto/AstoUploadTest.java
+++ b/src/test/java/com/artipie/docker/asto/AstoUploadTest.java
@@ -62,7 +62,7 @@ class AstoUploadTest {
     }
 
     @Test
-    void shouldAppendedChunk() {
+    void shouldReturnOffsetWhenAppendedChunk() {
         final byte[] chunk = "sample".getBytes();
         final Long offset = this.upload.append(Flowable.just(ByteBuffer.wrap(chunk)))
             .toCompletableFuture().join();

--- a/src/test/java/com/artipie/docker/http/UploadEntityPatchTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityPatchTest.java
@@ -61,7 +61,7 @@ class UploadEntityPatchTest {
     }
 
     @Test
-    void shouldReturnInitialUploadStatus() {
+    void shouldReturnUpdatedUploadStatus() {
         final byte[] data = "data".getBytes();
         final String uuid = UUID.randomUUID().toString();
         final String path = String.format("/v2/test/blobs/uploads/%s", uuid);
@@ -77,7 +77,7 @@ class UploadEntityPatchTest {
                     new RsHasStatus(RsStatus.ACCEPTED),
                     new RsHasHeaders(
                         new Header("Location", path),
-                        new Header("Range", String.format("0-%d", data.length)),
+                        new Header("Range", String.format("0-%d", data.length - 1)),
                         new Header("Content-Length", "0"),
                         new Header("Docker-Upload-UUID", uuid)
                     )


### PR DESCRIPTION
Part of #54 
Offset returned in upload status response should be inclusive. Next upload starts at previous offset+1.