### PR TITLE
#54 - Added Manifest.layers() method

### DIFF
--- a/src/main/java/com/artipie/docker/manifest/JsonManifest.java
+++ b/src/main/java/com/artipie/docker/manifest/JsonManifest.java
@@ -76,7 +76,7 @@ public final class JsonManifest implements Manifest {
     public CompletionStage<Collection<Digest>> layers() {
         return this.json().thenApply(
             root -> root.getJsonArray("layers").getValuesAs(JsonValue::asJsonObject).stream()
-                .map(obj -> obj.getString("digest"))
+                .map(layer -> layer.getString("digest"))
                 .map(Digest.FromString::new)
                 .collect(Collectors.toList())
         );

--- a/src/main/java/com/artipie/docker/manifest/JsonManifest.java
+++ b/src/main/java/com/artipie/docker/manifest/JsonManifest.java
@@ -24,9 +24,13 @@
 package com.artipie.docker.manifest;
 
 import com.artipie.asto.Content;
+import com.artipie.docker.Digest;
 import com.artipie.docker.misc.Json;
 import java.util.Collection;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
 
 /**
  * Image manifest in JSON format.
@@ -51,7 +55,7 @@ public final class JsonManifest implements Manifest {
 
     @Override
     public CompletionStage<String> mediaType() {
-        return new Json(this.source).object().thenApply(root -> root.getString("mediaType"));
+        return this.json().thenApply(root -> root.getString("mediaType"));
     }
 
     @Override
@@ -69,7 +73,26 @@ public final class JsonManifest implements Manifest {
     }
 
     @Override
+    public CompletionStage<Collection<Digest>> layers() {
+        return this.json().thenApply(
+            root -> root.getJsonArray("layers").getValuesAs(JsonValue::asJsonObject).stream()
+                .map(obj -> obj.getString("digest"))
+                .map(Digest.FromString::new)
+                .collect(Collectors.toList())
+        );
+    }
+
+    @Override
     public Content content() {
         return this.source;
+    }
+
+    /**
+     * Read manifest content as JSON object.
+     *
+     * @return JSON object.
+     */
+    private CompletionStage<JsonObject> json() {
+        return new Json(this.source).object();
     }
 }

--- a/src/main/java/com/artipie/docker/manifest/Manifest.java
+++ b/src/main/java/com/artipie/docker/manifest/Manifest.java
@@ -24,6 +24,7 @@
 package com.artipie.docker.manifest;
 
 import com.artipie.asto.Content;
+import com.artipie.docker.Digest;
 import java.util.Collection;
 import java.util.concurrent.CompletionStage;
 
@@ -49,6 +50,13 @@ public interface Manifest {
      * @return Converted manifest.
      */
     CompletionStage<Manifest> convert(Collection<String> options);
+
+    /**
+     * Read layer digests.
+     *
+     * @return Layer digests.
+     */
+    CompletionStage<Collection<Digest>> layers();
 
     /**
      * Read manifest binary content.

--- a/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
+++ b/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
@@ -26,10 +26,13 @@ package com.artipie.docker.manifest;
 import com.artipie.asto.Concatenation;
 import com.artipie.asto.Content;
 import com.artipie.asto.Remaining;
+import com.artipie.docker.Digest;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.jupiter.api.Assertions;
@@ -76,6 +79,21 @@ class JsonManifestTest {
         MatcherAssert.assertThat(
             exception.getCause(),
             new IsInstanceOf(IllegalArgumentException.class)
+        );
+    }
+
+    @Test
+    void shouldReadLayers() {
+        final JsonManifest manifest = new JsonManifest(
+            new Content.From(
+                "{\"layers\":[{\"digest\":\"sha256:123\"},{\"digest\":\"sha256:abc\"}]}".getBytes()
+            )
+        );
+        MatcherAssert.assertThat(
+            manifest.layers().toCompletableFuture().join().stream()
+                .map(Digest::string)
+                .collect(Collectors.toList()),
+            Matchers.containsInAnyOrder("sha256:123", "sha256:abc")
         );
     }
 


### PR DESCRIPTION
Part of #54 
Added Manifest.layers() method to read all manifest layer digests. This is required to check their presence when manifest is added.