### PR TITLE
#54 - Removed unused Repo.layer() method

### DIFF
--- a/src/main/java/com/artipie/docker/Repo.java
+++ b/src/main/java/com/artipie/docker/Repo.java
@@ -36,19 +36,6 @@ import java.util.concurrent.CompletionStage;
 public interface Repo {
 
     /**
-     * Layer link by algorithm and digest.
-     * <p>
-     * layerLinkPathSpec:
-     * <code>repositories/&lt;name&gt;/_layers/
-     * &lt;algorithm&gt;/&lt;hex digest&gt;/link</code>
-     * </p>
-     * @param alg Digest algorithm
-     * @param digest Digest hex string
-     * @return Digest of layer blob
-     */
-    Digest layer(String alg, String digest);
-
-    /**
      * Adds manifest stored as blob.
      *
      * @param ref Manifest reference.

--- a/src/main/java/com/artipie/docker/asto/AstoRepo.java
+++ b/src/main/java/com/artipie/docker/asto/AstoRepo.java
@@ -77,11 +77,6 @@ public final class AstoRepo implements Repo {
     }
 
     @Override
-    public Digest layer(final String alg, final String digest) {
-        throw new UnsupportedOperationException("not implemented");
-    }
-
-    @Override
     public CompletionStage<Void> addManifest(final ManifestRef ref, final Blob blob) {
         final Digest digest = blob.digest();
         return CompletableFuture.allOf(


### PR DESCRIPTION
Part of #54
`Repo.layer()` method has no usage and is not expected to be used