### PR TITLE
Head manifest endpoint #119

### DIFF
--- a/src/main/java/com/artipie/docker/http/DockerSlice.java
+++ b/src/main/java/com/artipie/docker/http/DockerSlice.java
@@ -58,7 +58,7 @@ public final class DockerSlice extends Slice.Wrap {
                         new RtRule.ByPath(ManifestEntity.PATH),
                         new RtRule.ByMethod(RqMethod.HEAD)
                     ),
-                    new ManifestEntity.Head()
+                    new ManifestEntity.Head(docker)
                 ),
                 new SliceRoute.Path(
                     new RtRule.Multiple(

--- a/src/main/java/com/artipie/docker/http/ManifestEntity.java
+++ b/src/main/java/com/artipie/docker/http/ManifestEntity.java
@@ -55,10 +55,6 @@ import org.reactivestreams.Publisher;
  * See <a href="https://docs.docker.com/registry/spec/api/#manifest">Manifest</a>.
  *
  * @since 0.2
- * @todo #119:30min Manifest GET and HEAD endpoints have to add Docker-Content-Digest header into
- *  response. Implement this functionality, for more details read about digest
- *  https://docs.docker.com/registry/spec/api/#content-digests and manifest endpoints
- *  https://docs.docker.com/registry/spec/api/#manifest.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class ManifestEntity {
@@ -106,16 +102,26 @@ final class ManifestEntity {
             return new AsyncResponse(
                 this.docker.repo(request.name()).manifest(request.reference()).thenCompose(
                     manifest -> manifest.<CompletionStage<Response>>map(
-                        original -> original.mediaType().thenApply(
-                            type -> new RsWithHeaders(
-                                StandardRs.EMPTY, new ContentType(type)
+                        found -> found.convert(Head.acceptHeader(headers))
+                            .thenCompose(
+                                original -> CompletableFuture.completedStage(
+                                    new BaseResponse(original)
+                                )
                             )
-                        )
                     ).orElseGet(
-                        () -> CompletableFuture.completedStage(StandardRs.NOT_FOUND)
+                        () -> CompletableFuture.completedStage(new RsWithStatus(RsStatus.NOT_FOUND))
                     )
                 )
             );
+        }
+
+        /**
+         * Gets accept header.
+         * @param headers Request headers
+         * @return Accept headers
+         */
+        private static RqHeaders acceptHeader(final Iterable<Map.Entry<String, String>> headers) {
+            return new RqHeaders(headers, "Accept");
         }
     }
 
@@ -151,9 +157,13 @@ final class ManifestEntity {
             final ManifestRef ref = request.reference();
             return new AsyncResponse(
                 this.docker.repo(name).manifest(ref).thenCompose(
-                    manifest -> manifest.map(
-                        original -> original.convert(new RqHeaders(headers, "Accept"))
-                            .thenCompose(Get::response)
+                    manifest -> manifest.<CompletionStage<Response>>map(
+                        found -> found.convert(Head.acceptHeader(headers))
+                            .thenCompose(
+                                original -> CompletableFuture.completedStage(
+                                    new RsWithBody(new BaseResponse(original), original.content())
+                                )
+                            )
                     ).orElseGet(
                         () -> CompletableFuture.completedStage(new RsWithStatus(RsStatus.NOT_FOUND))
                     )
@@ -161,20 +171,6 @@ final class ManifestEntity {
             );
         }
 
-        /**
-         * Create HTTP response from {@link Manifest}.
-         *
-         * @param manifest Manifest.
-         * @return HTTP response.
-         */
-        private static CompletionStage<Response> response(final Manifest manifest) {
-            return manifest.mediaType().thenApply(
-                type -> new RsWithBody(
-                    new RsWithHeaders(new RsWithStatus(RsStatus.OK), "Content-Type", type),
-                    manifest.content()
-                )
-            );
-        }
     }
 
     /**
@@ -283,5 +279,32 @@ final class ManifestEntity {
             }
             return matcher;
         }
+    }
+
+    /**
+     * Manifest base response.
+     * @since 0.2
+     * @todo #119:30min Manifest GET and HEAD endpoints have to add Docker-Content-Digest header
+     *  into response. Implement this functionality, for more details read about digest
+     *  https://docs.docker.com/registry/spec/api/#content-digests and manifest endpoints
+     *  https://docs.docker.com/registry/spec/api/#manifest.
+     */
+    static final class BaseResponse extends Response.Wrap {
+
+        /**
+         * Ctor.
+         *
+         * @param mnf Manifest
+         */
+        BaseResponse(final Manifest mnf) {
+            super(
+                new AsyncResponse(
+                    mnf.mediaType().thenApply(
+                        type -> new RsWithHeaders(StandardRs.EMPTY, new ContentType(type))
+                    )
+                )
+            );
+        }
+
     }
 }

--- a/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
@@ -62,18 +62,21 @@ class ManifestEntityHeadTest {
 
     @Test
     void shouldRespondOkWhenManifestFoundByTag() {
-        ManifestEntityHeadTest.assertion(
+        MatcherAssert.assertThat(
             this.slice.response(
                 new RequestLine("HEAD", "/v2/my-alpine/manifests/1", "HTTP/1.1").toString(),
-                Collections.emptyList(),
+                Collections.singleton(
+                    new Header("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+                ),
                 Flowable.empty()
-            )
+            ),
+            new ResponseMatcher()
         );
     }
 
     @Test
     void shouldRespondOkWhenManifestFoundByDigest() {
-        ManifestEntityHeadTest.assertion(
+        MatcherAssert.assertThat(
             this.slice.response(
                 new RequestLine(
                     "HEAD",
@@ -83,9 +86,12 @@ class ManifestEntityHeadTest {
                     ),
                     "HTTP/1.1"
                 ).toString(),
-                Collections.emptyList(),
+                Collections.singleton(
+                    new Header("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+                ),
                 Flowable.empty()
-            )
+            ),
+            new ResponseMatcher()
         );
     }
 
@@ -102,13 +108,16 @@ class ManifestEntityHeadTest {
     }
 
     /**
-     * Assertion.
-     * @param response Actual
+     * Response matcher.
+     * @since 0.2
      */
-    private static void assertion(final Response response) {
-        MatcherAssert.assertThat(
-            response,
-            new AllOf<>(
+    private static class ResponseMatcher extends AllOf<Response> {
+
+        /**
+         * Ctor.
+         */
+        ResponseMatcher() {
+            super(
                 new ListOf<Matcher<? super Response>>(
                     new RsHasStatus(RsStatus.OK),
                     new RsHasHeaders(
@@ -117,7 +126,7 @@ class ManifestEntityHeadTest {
                         )
                     )
                 )
-            )
-        );
+            );
+        }
     }
 }

--- a/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
@@ -26,12 +26,17 @@ package com.artipie.docker.http;
 import com.artipie.docker.ExampleStorage;
 import com.artipie.docker.asto.AstoDocker;
 import com.artipie.http.Response;
+import com.artipie.http.hm.RsHasHeaders;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rs.Header;
 import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
 import java.util.Collections;
+import org.cactoos.list.ListOf;
+import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,6 +45,7 @@ import org.junit.jupiter.api.Test;
  * Manifest HEAD endpoint.
  *
  * @since 0.2
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class ManifestEntityHeadTest {
@@ -56,34 +62,62 @@ class ManifestEntityHeadTest {
 
     @Test
     void shouldRespondOkWhenManifestFoundByTag() {
-        final Response response = this.slice.response(
-            new RequestLine("HEAD", "/v2/my-alpine/manifests/1", "HTTP/1.1").toString(),
-            Collections.emptyList(),
-            Flowable.empty()
-        );
-        MatcherAssert.assertThat(
-            response,
-            new RsHasStatus(RsStatus.OK)
+        ManifestEntityHeadTest.assertion(
+            this.slice.response(
+                new RequestLine("HEAD", "/v2/my-alpine/manifests/1", "HTTP/1.1").toString(),
+                Collections.emptyList(),
+                Flowable.empty()
+            )
         );
     }
 
     @Test
     void shouldRespondOkWhenManifestFoundByDigest() {
-        final Response response = this.slice.response(
-            new RequestLine(
-                "HEAD",
-                String.format(
-                    "/v2/my-alpine/manifests/%s",
-                    "sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221"
-                ),
-                "HTTP/1.1"
-            ).toString(),
-            Collections.emptyList(),
-            Flowable.empty()
+        ManifestEntityHeadTest.assertion(
+            this.slice.response(
+                new RequestLine(
+                    "HEAD",
+                    String.format(
+                        "/v2/my-alpine/manifests/%s",
+                        "sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221"
+                    ),
+                    "HTTP/1.1"
+                ).toString(),
+                Collections.emptyList(),
+                Flowable.empty()
+            )
         );
+    }
+
+    @Test
+    void shouldReturnNotFoundForUnknownTag() {
+        MatcherAssert.assertThat(
+            this.slice.response(
+                new RequestLine("HEAD", "/v2/my-alpine/manifests/2", "HTTP/1.1").toString(),
+                Collections.emptyList(),
+                Flowable.empty()
+            ),
+            new RsHasStatus(RsStatus.NOT_FOUND)
+        );
+    }
+
+    /**
+     * Assertion.
+     * @param response Actual
+     */
+    private static void assertion(final Response response) {
         MatcherAssert.assertThat(
             response,
-            new RsHasStatus(RsStatus.OK)
+            new AllOf<>(
+                new ListOf<Matcher<? super Response>>(
+                    new RsHasStatus(RsStatus.OK),
+                    new RsHasHeaders(
+                        new Header(
+                            "Content-type", "application/vnd.docker.distribution.manifest.v2+json"
+                        )
+                    )
+                )
+            )
         );
     }
 }

--- a/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
@@ -25,18 +25,13 @@ package com.artipie.docker.http;
 
 import com.artipie.docker.ExampleStorage;
 import com.artipie.docker.asto.AstoDocker;
-import com.artipie.http.Response;
-import com.artipie.http.hm.RsHasHeaders;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rs.Header;
 import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
 import java.util.Collections;
-import org.cactoos.list.ListOf;
-import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -107,26 +102,4 @@ class ManifestEntityHeadTest {
         );
     }
 
-    /**
-     * Response matcher.
-     * @since 0.2
-     */
-    private static class ResponseMatcher extends AllOf<Response> {
-
-        /**
-         * Ctor.
-         */
-        ResponseMatcher() {
-            super(
-                new ListOf<Matcher<? super Response>>(
-                    new RsHasStatus(RsStatus.OK),
-                    new RsHasHeaders(
-                        new Header(
-                            "Content-type", "application/vnd.docker.distribution.manifest.v2+json"
-                        )
-                    )
-                )
-            );
-        }
-    }
 }

--- a/src/test/java/com/artipie/docker/http/ResponseMatcher.java
+++ b/src/test/java/com/artipie/docker/http/ResponseMatcher.java
@@ -1,0 +1,61 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.http;
+
+import com.artipie.http.Response;
+import com.artipie.http.hm.RsHasHeaders;
+import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.rs.Header;
+import com.artipie.http.rs.RsStatus;
+import org.cactoos.list.ListOf;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.AllOf;
+
+/**
+ * Response matcher.
+ * @since 0.2
+ * @todo #119:30min There are a lot of `AllOf<>` matcher creation duplications in this package test
+ *  classes. Use this class to get rid of duplications: for example, we can add ctor with content
+ *  and get rid of the
+ *  com.artipie.docker.http.ManifestEntityGetTest#success(com.artipie.asto.Key)
+ *  method.
+ */
+final class ResponseMatcher extends AllOf<Response> {
+
+    /**
+     * Ctor.
+     */
+    ResponseMatcher() {
+        super(
+            new ListOf<Matcher<? super Response>>(
+                new RsHasStatus(RsStatus.OK),
+                new RsHasHeaders(
+                    new Header(
+                        "Content-type", "application/vnd.docker.distribution.manifest.v2+json"
+                    )
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
For #119 I've implemented manifest head endpoint, extended test and added todo to add `Docker-Content-Digest` to get and head.