### PR TITLE
#54 - Reading config digest from manifest

### DIFF
--- a/src/main/java/com/artipie/docker/manifest/Manifest.java
+++ b/src/main/java/com/artipie/docker/manifest/Manifest.java
@@ -52,6 +52,13 @@ public interface Manifest {
     CompletionStage<Manifest> convert(Collection<String> options);
 
     /**
+     * Read config digest.
+     *
+     * @return Config digests.
+     */
+    CompletionStage<Digest> config();
+
+    /**
      * Read layer digests.
      *
      * @return Layer digests.

--- a/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
+++ b/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.2
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class JsonManifestTest {
 
     @Test
@@ -81,6 +82,23 @@ class JsonManifestTest {
         MatcherAssert.assertThat(
             exception.getCause(),
             new IsInstanceOf(IllegalArgumentException.class)
+        );
+    }
+
+    @Test
+    void shouldReadConfig() {
+        final String digest = "sha256:def";
+        final JsonManifest manifest = new JsonManifest(
+            new Content.From(
+                Json.createObjectBuilder().add(
+                    "config",
+                    Json.createObjectBuilder().add("digest", digest)
+                ).build().toString().getBytes()
+            )
+        );
+        MatcherAssert.assertThat(
+            manifest.config().toCompletableFuture().join().string(),
+            new IsEqual<>(digest)
         );
     }
 


### PR DESCRIPTION
Part of #54 
Reading config digest from image manifest, that should be used for manifest validation