### PR TITLE
#136 - Moved upload start logic to Repo.startUpload method

### DIFF
--- a/src/main/java/com/artipie/docker/Repo.java
+++ b/src/main/java/com/artipie/docker/Repo.java
@@ -52,6 +52,13 @@ public interface Repo {
     CompletionStage<Optional<Manifest>> manifest(ManifestRef ref);
 
     /**
+     * Start new upload.
+     *
+     * @return Upload.
+     */
+    CompletionStage<Upload> startUpload();
+
+    /**
      * Find upload by UUID.
      *
      * @param uuid Upload UUID.

--- a/src/main/java/com/artipie/docker/Upload.java
+++ b/src/main/java/com/artipie/docker/Upload.java
@@ -37,6 +37,13 @@ import org.reactivestreams.Publisher;
 public interface Upload {
 
     /**
+     * Read UUID.
+     *
+     * @return UUID.
+     */
+    String uuid();
+
+    /**
      * Appends a chunk of data to upload.
      *
      * @param chunk Chunk of data.

--- a/src/main/java/com/artipie/docker/asto/AstoRepo.java
+++ b/src/main/java/com/artipie/docker/asto/AstoRepo.java
@@ -38,6 +38,7 @@ import com.artipie.docker.manifest.Manifest;
 import com.artipie.docker.misc.BytesFlowAs;
 import com.artipie.docker.ref.ManifestRef;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
@@ -107,6 +108,12 @@ public final class AstoRepo implements Repo {
                     )
             ).orElseGet(() -> CompletableFuture.completedFuture(Optional.empty()))
         );
+    }
+
+    @Override
+    public CompletionStage<Upload> startUpload() {
+        final String uuid = UUID.randomUUID().toString();
+        return CompletableFuture.completedFuture(new AstoUpload(this.asto, this.name, uuid));
     }
 
     @Override

--- a/src/main/java/com/artipie/docker/asto/AstoUpload.java
+++ b/src/main/java/com/artipie/docker/asto/AstoUpload.java
@@ -53,6 +53,7 @@ public final class AstoUpload implements Upload {
     /**
      * Upload UUID.
      */
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     private final String uuid;
 
     /**
@@ -66,6 +67,11 @@ public final class AstoUpload implements Upload {
         this.storage = storage;
         this.name = name;
         this.uuid = uuid;
+    }
+
+    @Override
+    public String uuid() {
+        return this.uuid;
     }
 
     @Override

--- a/src/main/java/com/artipie/docker/http/DockerSlice.java
+++ b/src/main/java/com/artipie/docker/http/DockerSlice.java
@@ -93,7 +93,7 @@ public final class DockerSlice extends Slice.Wrap {
                         new RtRule.ByPath(UploadEntity.PATH),
                         new RtRule.ByMethod(RqMethod.POST)
                     ),
-                    new UploadEntity.Post()
+                    new UploadEntity.Post(docker)
                 ),
                 new SliceRoute.Path(
                     new RtRule.Multiple(

--- a/src/main/java/com/artipie/docker/http/UploadEntity.java
+++ b/src/main/java/com/artipie/docker/http/UploadEntity.java
@@ -39,7 +39,6 @@ import com.artipie.http.rs.RsWithStatus;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -76,6 +75,20 @@ public final class UploadEntity {
      */
     public static final class Post implements Slice {
 
+        /**
+         * Docker repository.
+         */
+        private final Docker docker;
+
+        /**
+         * Ctor.
+         *
+         * @param docker Docker repository.
+         */
+        Post(final Docker docker) {
+            this.docker = docker;
+        }
+
         @Override
         public Response response(
             final String line,
@@ -83,8 +96,11 @@ public final class UploadEntity {
             final Publisher<ByteBuffer> body
         ) {
             final RepoName name = new Request(line).name();
-            final String uuid = UUID.randomUUID().toString();
-            return new StatusResponse(name, uuid, 0);
+            return new AsyncResponse(
+                this.docker.repo(name).startUpload().thenApply(
+                    upload -> new StatusResponse(name, upload.uuid(), 0)
+                )
+            );
         }
     }
 


### PR DESCRIPTION
Part of #136 
Added `Repo.startUpload()` method to encapsulate upload start logic. Result is async so writing is storage will be simple to add later.