### PR TITLE
#131 - Reading Manifest layer URLs

### DIFF
--- a/src/main/java/com/artipie/docker/asto/AstoRepo.java
+++ b/src/main/java/com/artipie/docker/asto/AstoRepo.java
@@ -34,6 +34,7 @@ import com.artipie.docker.Repo;
 import com.artipie.docker.RepoName;
 import com.artipie.docker.Upload;
 import com.artipie.docker.manifest.JsonManifest;
+import com.artipie.docker.manifest.Layer;
 import com.artipie.docker.manifest.Manifest;
 import com.artipie.docker.misc.BytesFlowAs;
 import com.artipie.docker.ref.ManifestRef;
@@ -124,7 +125,7 @@ public final class AstoRepo implements Repo {
         return manifest.config()
             .thenCompose(
                 config -> manifest.layers().thenApply(
-                    layers -> Stream.concat(Stream.of(config), layers.stream())
+                    layers -> Stream.concat(Stream.of(config), layers.stream().map(Layer::digest))
                 )
             )
             .thenCompose(

--- a/src/main/java/com/artipie/docker/manifest/Layer.java
+++ b/src/main/java/com/artipie/docker/manifest/Layer.java
@@ -23,52 +23,28 @@
  */
 package com.artipie.docker.manifest;
 
-import com.artipie.asto.Content;
 import com.artipie.docker.Digest;
+import java.net.URL;
 import java.util.Collection;
-import java.util.concurrent.CompletionStage;
 
 /**
- * Image manifest.
- * See <a href="https://docs.docker.com/engine/reference/commandline/manifest/">docker manifest</a>
+ * Image layer.
  *
  * @since 0.2
  */
-public interface Manifest {
+public interface Layer {
 
     /**
-     * Read manifest type.
+     * Read layer content digest.
      *
-     * @return Type string.
+     * @return Layer content digest..
      */
-    CompletionStage<String> mediaType();
+    Digest digest();
 
     /**
-     * Converts manifest to one of types.
+     * Provides a list of URLs from which the content may be fetched.
      *
-     * @param options Types the manifest may be converted to.
-     * @return Converted manifest.
+     * @return URLs, might be empty
      */
-    CompletionStage<Manifest> convert(Collection<String> options);
-
-    /**
-     * Read config digest.
-     *
-     * @return Config digests.
-     */
-    CompletionStage<Digest> config();
-
-    /**
-     * Read layer digests.
-     *
-     * @return Layer digests.
-     */
-    CompletionStage<Collection<Layer>> layers();
-
-    /**
-     * Read manifest binary content.
-     *
-     * @return Manifest binary content.
-     */
-    Content content();
+    Collection<URL> urls();
 }

--- a/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
+++ b/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
@@ -30,7 +30,6 @@ import com.artipie.docker.Digest;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,6 +38,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsInstanceOf;
+import org.hamcrest.core.IsIterableContaining;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.Test;
  * Tests for {@link JsonManifest}.
  *
  * @since 0.2
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class JsonManifestTest {
@@ -149,8 +150,8 @@ class JsonManifestTest {
         MatcherAssert.assertThat(
             manifest.layers().toCompletableFuture().join().stream()
                 .flatMap(layer -> layer.urls().stream())
-                .findFirst(),
-            new IsEqual<>(Optional.of(new URL(url)))
+                .collect(Collectors.toList()),
+            new IsIterableContaining<>(new IsEqual<>(new URL(url)))
         );
     }
 


### PR DESCRIPTION
Part of #131 
Reading layer URLs from manifest. These layers are foreign and are not required to be present in blob store when manifest is added 