### PR TITLE
#128 - Added Manifest.digest() method

### DIFF
--- a/src/main/java/com/artipie/docker/asto/AstoRepo.java
+++ b/src/main/java/com/artipie/docker/asto/AstoRepo.java
@@ -83,7 +83,7 @@ public final class AstoRepo implements Repo {
     public CompletionStage<Void> addManifest(final ManifestRef ref, final Blob blob) {
         final Digest digest = blob.digest();
         return blob.content()
-            .thenApply(JsonManifest::new)
+            .thenApply(source -> new JsonManifest(blob.digest(), source))
             .thenCompose(this::validate)
             .thenCompose(
                 ignored -> CompletableFuture.allOf(
@@ -102,7 +102,9 @@ public final class AstoRepo implements Repo {
                         blobOpt -> blobOpt
                             .map(
                                 blob -> blob.content()
-                                    .<Manifest>thenApply(JsonManifest::new)
+                                    .<Manifest>thenApply(
+                                        source -> new JsonManifest(blob.digest(), source)
+                                    )
                                     .thenApply(Optional::of)
                             )
                             .orElseGet(() -> CompletableFuture.completedFuture(Optional.empty()))

--- a/src/main/java/com/artipie/docker/manifest/JsonManifest.java
+++ b/src/main/java/com/artipie/docker/manifest/JsonManifest.java
@@ -48,7 +48,7 @@ public final class JsonManifest implements Manifest {
     /**
      * Manifest digest.
      */
-    private final Digest dig;
+    private final Digest dgst;
 
     /**
      * JSON bytes.
@@ -58,11 +58,11 @@ public final class JsonManifest implements Manifest {
     /**
      * Ctor.
      *
-     * @param dig Manifest digest.
+     * @param dgst Manifest digest.
      * @param source JSON bytes.
      */
-    public JsonManifest(final Digest dig, final Content source) {
-        this.dig = dig;
+    public JsonManifest(final Digest dgst, final Content source) {
+        this.dgst = dgst;
         this.source = source;
     }
 
@@ -103,7 +103,7 @@ public final class JsonManifest implements Manifest {
 
     @Override
     public Digest digest() {
-        return this.dig;
+        return this.dgst;
     }
 
     @Override

--- a/src/main/java/com/artipie/docker/manifest/JsonManifest.java
+++ b/src/main/java/com/artipie/docker/manifest/JsonManifest.java
@@ -46,6 +46,11 @@ import javax.json.JsonValue;
 public final class JsonManifest implements Manifest {
 
     /**
+     * Manifest digest.
+     */
+    private final Digest dig;
+
+    /**
      * JSON bytes.
      */
     private final Content source;
@@ -53,9 +58,11 @@ public final class JsonManifest implements Manifest {
     /**
      * Ctor.
      *
+     * @param dig Manifest digest.
      * @param source JSON bytes.
      */
-    public JsonManifest(final Content source) {
+    public JsonManifest(final Digest dig, final Content source) {
+        this.dig = dig;
         this.source = source;
     }
 
@@ -92,6 +99,11 @@ public final class JsonManifest implements Manifest {
                 .map(JsonLayer::new)
                 .collect(Collectors.toList())
         );
+    }
+
+    @Override
+    public Digest digest() {
+        return this.dig;
     }
 
     @Override

--- a/src/main/java/com/artipie/docker/manifest/Manifest.java
+++ b/src/main/java/com/artipie/docker/manifest/Manifest.java
@@ -66,6 +66,13 @@ public interface Manifest {
     CompletionStage<Collection<Layer>> layers();
 
     /**
+     * Manifest digest.
+     *
+     * @return Digest.
+     */
+    Digest digest();
+
+    /**
      * Read manifest binary content.
      *
      * @return Manifest binary content.

--- a/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
+++ b/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
@@ -54,6 +54,7 @@ class JsonManifestTest {
     @Test
     void shouldReadMediaType() throws Exception {
         final JsonManifest manifest = new JsonManifest(
+            new Digest.Sha256("123"),
             new Content.From("{\"mediaType\":\"something\"}".getBytes())
         );
         MatcherAssert.assertThat(
@@ -65,6 +66,7 @@ class JsonManifestTest {
     @Test
     void shouldConvertToSameType() throws Exception {
         final JsonManifest manifest = new JsonManifest(
+            new Digest.Sha256("123"),
             new Content.From("{\"mediaType\":\"type2\"}".getBytes())
         );
         MatcherAssert.assertThat(
@@ -76,6 +78,7 @@ class JsonManifestTest {
     @Test
     void shouldFailConvertToUnknownType() {
         final JsonManifest manifest = new JsonManifest(
+            new Digest.Sha256("123"),
             new Content.From("{\"mediaType\":\"typeA\"}".getBytes())
         );
         final ExecutionException exception = Assertions.assertThrows(
@@ -92,6 +95,7 @@ class JsonManifestTest {
     void shouldReadConfig() {
         final String digest = "sha256:def";
         final JsonManifest manifest = new JsonManifest(
+            new Digest.Sha256("123"),
             new Content.From(
                 Json.createObjectBuilder().add(
                     "config",
@@ -109,6 +113,7 @@ class JsonManifestTest {
     void shouldReadLayerDigests() {
         final String[] digests = {"sha256:123", "sha256:abc"};
         final JsonManifest manifest = new JsonManifest(
+            new Digest.Sha256("123"),
             new Content.From(
                 Json.createObjectBuilder().add(
                     "layers",
@@ -133,6 +138,7 @@ class JsonManifestTest {
     void shouldReadLayerUrls() throws Exception {
         final String url = "https://artipie.com/";
         final JsonManifest manifest = new JsonManifest(
+            new Digest.Sha256("123"),
             new Content.From(
                 Json.createObjectBuilder().add(
                     "layers",
@@ -156,9 +162,25 @@ class JsonManifestTest {
     }
 
     @Test
+    void shouldReadDigest() {
+        final String digest = "sha256:123";
+        final JsonManifest manifest = new JsonManifest(
+            new Digest.FromString(digest),
+            new Content.From("something".getBytes())
+        );
+        MatcherAssert.assertThat(
+            manifest.digest().string(),
+            new IsEqual<>(digest)
+        );
+    }
+
+    @Test
     void shouldReadContent() {
         final byte[] data = "data".getBytes();
-        final JsonManifest manifest = new JsonManifest(new Content.From(data));
+        final JsonManifest manifest = new JsonManifest(
+            new Digest.Sha256("123"),
+            new Content.From(data)
+        );
         MatcherAssert.assertThat(
             new Remaining(new Concatenation(manifest.content()).single().blockingGet()).bytes(),
             new IsEqual<>(data)

--- a/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
+++ b/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
@@ -113,7 +113,7 @@ class JsonManifestTest {
     void shouldReadLayerDigests() {
         final String[] digests = {"sha256:123", "sha256:abc"};
         final JsonManifest manifest = new JsonManifest(
-            new Digest.Sha256("123"),
+            new Digest.Sha256("12345"),
             new Content.From(
                 Json.createObjectBuilder().add(
                     "layers",


### PR DESCRIPTION
Part of #128 
 Added `Manifest.digest()` method so digest could be read from manifest instance in slice