### PR TITLE
#131 - Foreign layers validation in AstoRepo

### DIFF
--- a/src/main/java/com/artipie/docker/asto/AstoRepo.java
+++ b/src/main/java/com/artipie/docker/asto/AstoRepo.java
@@ -134,7 +134,10 @@ public final class AstoRepo implements Repo {
         return manifest.config()
             .thenCompose(
                 config -> manifest.layers().thenApply(
-                    layers -> Stream.concat(Stream.of(config), layers.stream().map(Layer::digest))
+                    layers -> Stream.concat(
+                        Stream.of(config),
+                        layers.stream().filter(layer -> layer.urls().isEmpty()).map(Layer::digest)
+                    )
                 )
             )
             .thenCompose(


### PR DESCRIPTION
Part of #131 
Added foreign layers validation support to AstoRepo. This kind of layers is used in Windows images.