### PR TITLE
#128 - Added Docker-Content-Digest header to manifest responses

### DIFF
--- a/src/main/java/com/artipie/docker/http/ManifestEntity.java
+++ b/src/main/java/com/artipie/docker/http/ManifestEntity.java
@@ -284,10 +284,6 @@ final class ManifestEntity {
     /**
      * Manifest base response.
      * @since 0.2
-     * @todo #119:30min Manifest GET and HEAD endpoints have to add Docker-Content-Digest header
-     *  into response. Implement this functionality, for more details read about digest
-     *  https://docs.docker.com/registry/spec/api/#content-digests and manifest endpoints
-     *  https://docs.docker.com/registry/spec/api/#manifest.
      */
     static final class BaseResponse extends Response.Wrap {
 
@@ -300,7 +296,11 @@ final class ManifestEntity {
             super(
                 new AsyncResponse(
                     mnf.mediaType().thenApply(
-                        type -> new RsWithHeaders(StandardRs.EMPTY, new ContentType(type))
+                        type -> new RsWithHeaders(
+                            StandardRs.EMPTY,
+                            new ContentType(type),
+                            new DigestHeader(mnf.digest())
+                        )
                     )
                 )
             );

--- a/src/test/java/com/artipie/docker/http/ManifestEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityGetTest.java
@@ -85,11 +85,8 @@ class ManifestEntityGetTest {
 
     @Test
     void shouldReturnManifestByDigest() {
-        final String digest = String.format(
-            "%s:%s",
-            "sha256",
-            "cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221"
-        );
+        final String hex = "cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221";
+        final String digest = String.format("%s:%s", "sha256", hex);
         MatcherAssert.assertThat(
             this.slice.response(
                 new RequestLine(
@@ -104,10 +101,7 @@ class ManifestEntityGetTest {
             ),
             success(
                 digest,
-                new Key.From(
-                    "docker", "registry", "v2", "blobs", "sha256", "cb",
-                    "cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221", "data"
-                )
+                new Key.From("docker", "registry", "v2", "blobs", "sha256", "cb", hex, "data")
             )
         );
     }

--- a/src/test/java/com/artipie/docker/http/ManifestEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityGetTest.java
@@ -74,6 +74,7 @@ class ManifestEntityGetTest {
                 Flowable.empty()
             ),
             success(
+                "sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221",
                 new Key.From(
                     "docker", "registry", "v2", "blobs", "sha256", "cb",
                     "cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221", "data"
@@ -84,14 +85,16 @@ class ManifestEntityGetTest {
 
     @Test
     void shouldReturnManifestByDigest() {
+        final String digest = String.format(
+            "%s:%s",
+            "sha256",
+            "cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221"
+        );
         MatcherAssert.assertThat(
             this.slice.response(
                 new RequestLine(
                     "GET",
-                    String.format(
-                        "/v2/my-alpine/manifests/%s",
-                        "sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221"
-                    ),
+                    String.format("/v2/my-alpine/manifests/%s", digest),
                     "HTTP/1.1"
                 ).toString(),
                 Collections.singleton(
@@ -100,6 +103,7 @@ class ManifestEntityGetTest {
                 Flowable.empty()
             ),
             success(
+                digest,
                 new Key.From(
                     "docker", "registry", "v2", "blobs", "sha256", "cb",
                     "cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221", "data"
@@ -139,7 +143,10 @@ class ManifestEntityGetTest {
         );
     }
 
-    private static Matcher<Response> success(final Key content) {
+    private static Matcher<Response> success(
+        final String digest,
+        final Key content
+    ) {
         return new AllOf<>(
             Arrays.asList(
                 new RsHasStatus(RsStatus.OK),
@@ -147,7 +154,8 @@ class ManifestEntityGetTest {
                     new Header(
                         "Content-Type",
                         "application/vnd.docker.distribution.manifest.v2+json"
-                    )
+                    ),
+                    new Header("Docker-Content-Digest", digest)
                 ),
                 new RsHasBody(
                     new BlockingStorage(new ExampleStorage()).value(content)

--- a/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
@@ -65,20 +65,24 @@ class ManifestEntityHeadTest {
                 ),
                 Flowable.empty()
             ),
-            new ResponseMatcher()
+            new ResponseMatcher(
+                "sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221"
+            )
         );
     }
 
     @Test
     void shouldRespondOkWhenManifestFoundByDigest() {
+        final String digest = String.format(
+            "%s:%s",
+            "sha256",
+            "cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221"
+        );
         MatcherAssert.assertThat(
             this.slice.response(
                 new RequestLine(
                     "HEAD",
-                    String.format(
-                        "/v2/my-alpine/manifests/%s",
-                        "sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221"
-                    ),
+                    String.format("/v2/my-alpine/manifests/%s", digest),
                     "HTTP/1.1"
                 ).toString(),
                 Collections.singleton(
@@ -86,7 +90,7 @@ class ManifestEntityHeadTest {
                 ),
                 Flowable.empty()
             ),
-            new ResponseMatcher()
+            new ResponseMatcher(digest)
         );
     }
 

--- a/src/test/java/com/artipie/docker/http/ResponseMatcher.java
+++ b/src/test/java/com/artipie/docker/http/ResponseMatcher.java
@@ -45,15 +45,18 @@ final class ResponseMatcher extends AllOf<Response> {
 
     /**
      * Ctor.
+     *
+     * @param digest Expected `Docker-Content-Digest` header value.
      */
-    ResponseMatcher() {
+    ResponseMatcher(final String digest) {
         super(
             new ListOf<Matcher<? super Response>>(
                 new RsHasStatus(RsStatus.OK),
                 new RsHasHeaders(
                     new Header(
                         "Content-type", "application/vnd.docker.distribution.manifest.v2+json"
-                    )
+                    ),
+                    new Header("Docker-Content-Digest", digest)
                 )
             )
         );


### PR DESCRIPTION
Closes #128 
Added Docker-Content-Digest header to manifest GET and HEAD responses