### PR TITLE
#136 - Extracted UploadKey

### DIFF
--- a/src/main/java/com/artipie/docker/asto/AstoUpload.java
+++ b/src/main/java/com/artipie/docker/asto/AstoUpload.java
@@ -127,10 +127,7 @@ public final class AstoUpload implements Upload {
      * @return Root key.
      */
     Key root() {
-        return new Key.From(
-            RegistryRoot.V2, "repositories", this.name.value(),
-            "_uploads", this.uuid
-        );
+        return new UploadKey(this.name, this.uuid);
     }
 
     /**

--- a/src/main/java/com/artipie/docker/asto/UploadKey.java
+++ b/src/main/java/com/artipie/docker/asto/UploadKey.java
@@ -1,0 +1,51 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.artipie.docker.asto;
+
+import com.artipie.asto.Key;
+import com.artipie.docker.RepoName;
+
+/**
+ * Key of blob upload root.
+ *
+ * @since 0.3
+ */
+final class UploadKey extends Key.Wrap {
+
+    /**
+     * Ctor.
+     *
+     * @param name Repository name.
+     * @param uuid Upload UUID.
+     */
+    UploadKey(final RepoName name, final String uuid) {
+        super(
+            new Key.From(
+                RegistryRoot.V2, "repositories", name.value(),
+                "_uploads", uuid
+            )
+        );
+    }
+}

--- a/src/test/java/com/artipie/docker/asto/UploadKeyTest.java
+++ b/src/test/java/com/artipie/docker/asto/UploadKeyTest.java
@@ -24,6 +24,7 @@
 package com.artipie.docker.asto;
 
 import com.artipie.docker.RepoName;
+import java.util.UUID;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,7 @@ public final class UploadKeyTest {
     @Test
     public void shouldBuildExpectedString() {
         final String name = "test";
-        final String uuid = "12345";
+        final String uuid = UUID.randomUUID().toString();
         MatcherAssert.assertThat(
             new UploadKey(new RepoName.Valid(name), uuid).string(),
             Matchers.equalTo(

--- a/src/test/java/com/artipie/docker/asto/UploadKeyTest.java
+++ b/src/test/java/com/artipie/docker/asto/UploadKeyTest.java
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.asto;
+
+import com.artipie.docker.RepoName;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link UploadKey}.
+ *
+ * @since 0.3
+ */
+public final class UploadKeyTest {
+
+    @Test
+    public void shouldBuildExpectedString() {
+        final String name = "test";
+        final String uuid = "12345";
+        MatcherAssert.assertThat(
+            new UploadKey(new RepoName.Valid(name), uuid).string(),
+            Matchers.equalTo(
+                String.format("docker/registry/v2/repositories/%s/_uploads/%s", name, uuid)
+            )
+        );
+    }
+}


### PR DESCRIPTION
Part of #136 
Added `UploadKey` class which represents path to blob upload root. It is required to construct this key outside of `AstoUpload` class to check if upload exists.