### PR TITLE
#175 - calc digest once on blob put

### DIFF
--- a/src/main/java/com/artipie/docker/BlobStore.java
+++ b/src/main/java/com/artipie/docker/BlobStore.java
@@ -44,8 +44,9 @@ public interface BlobStore {
     /**
      * Put data into blob store and calculate its digest.
      * @param blob Data flow
+     * @param digest Digest of the data
      * @return Future with digest
      */
-    CompletionStage<Blob> put(Content blob);
+    CompletionStage<Blob> put(Content blob, Digest digest);
 }
 

--- a/src/main/java/com/artipie/docker/asto/AstoRepo.java
+++ b/src/main/java/com/artipie/docker/asto/AstoRepo.java
@@ -95,7 +95,7 @@ public final class AstoRepo implements Repo {
             .map(Remaining::new)
             .map(Remaining::bytes)
             .to(SingleInterop.get())
-            .thenCompose(bytes -> this.blobs.put(new Content.From(bytes)))
+            .thenCompose(bytes -> this.blobs.put(new Content.From(bytes), new Digest.Sha256(bytes)))
             .thenCompose(
                 blob -> {
                     final Digest digest = blob.digest();

--- a/src/main/java/com/artipie/docker/http/UploadEntity.java
+++ b/src/main/java/com/artipie/docker/http/UploadEntity.java
@@ -23,10 +23,10 @@
  */
 package com.artipie.docker.http;
 
-import com.artipie.asto.Content;
 import com.artipie.docker.Digest;
 import com.artipie.docker.Docker;
 import com.artipie.docker.RepoName;
+import com.artipie.docker.Upload;
 import com.artipie.docker.misc.DigestFromContent;
 import com.artipie.http.Connection;
 import com.artipie.http.Response;
@@ -40,7 +40,6 @@ import com.artipie.http.rs.RsWithStatus;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.regex.Matcher;
@@ -162,9 +161,6 @@ public final class UploadEntity {
      *  digests and then to write upload as a blob. Such approach is inefficient and should be
      *  fixed. One of the possible solution is moving the comparison logic inside
      *  BlobStore.put() method.
-     * @todo #158:30min Digest is calculated twice while blob is added: first we calculate if here
-     *  and then inside AstoBlobs#put() method. One of the possible solutions here is to pass digest
-     *  to AstoBlobs#put().
      */
     public static final class Put implements Slice {
 
@@ -192,50 +188,56 @@ public final class UploadEntity {
             final RepoName name = request.name();
             final String uuid = request.uuid();
             return new AsyncResponse(
-                this.docker.repo(new RepoName.Valid(name)).upload(uuid).thenCompose(
+                this.docker.repo(name).upload(uuid).<Response>thenCompose(
                     found -> found.map(
-                        upload -> upload.content()
-                            .thenCompose(
-                                content -> new DigestFromContent(content).digest().thenApply(
-                                    digest -> {
-                                        final Optional<Content> res;
-                                        if (digest.string().equals(request.digest().string())) {
-                                            res = Optional.of(content);
-                                        } else {
-                                            res = Optional.empty();
-                                        }
-                                        return res;
+                        upload -> upload.content().thenCompose(
+                            content -> new DigestFromContent(content).digest().thenCompose(
+                                digest -> {
+                                    final CompletionStage<Response> res;
+                                    if (digest.string().equals(request.digest().string())) {
+                                        res = this.docker.blobStore().put(content, digest)
+                                            .thenCompose(
+                                                blob -> Put.delAndGetResponse(name, upload, digest)
+                                            );
+                                    } else {
+                                        res = CompletableFuture.completedStage(
+                                            new RsWithStatus(RsStatus.BAD_REQUEST)
+                                        );
                                     }
-                                )
-                            ).thenApply(
-                                opt -> opt.<Response>map(
-                                    content -> new AsyncResponse(
-                                        this.docker.blobStore().put(content).thenCompose(
-                                            blob -> {
-                                                final Digest digest = blob.digest();
-                                                return upload.delete().thenApply(
-                                                    ignored -> new RsWithHeaders(
-                                                        new RsWithStatus(RsStatus.CREATED),
-                                                        new Header(
-                                                            "Location",
-                                                            String.format(
-                                                                "/v2/%s/blobs/%s",
-                                                                name.value(),
-                                                                digest.string()
-                                                            )
-                                                        ),
-                                                        new Header("Content-Length", "0"),
-                                                        new DigestHeader(digest)
-                                                    )
-                                                );
-                                            }
-                                        )
-                                    )
-                                ).orElse(new RsWithStatus(RsStatus.BAD_REQUEST))
+                                    return res;
+                                }
                             )
+                        )
                     ).orElseGet(
                         () -> CompletableFuture.completedStage(new RsWithStatus(RsStatus.NOT_FOUND))
                     )
+                )
+            );
+        }
+
+        /**
+         * Deletes content after upload and returns response.
+         * @param name Repo name
+         * @param upload Upload
+         * @param digest Digest
+         * @return Response as CompletionStage
+         */
+        private static CompletionStage<Response> delAndGetResponse(
+            final RepoName name, final Upload upload, final Digest digest
+        ) {
+            return upload.delete().thenApply(
+                ignored -> new RsWithHeaders(
+                    new RsWithStatus(RsStatus.CREATED),
+                    new Header(
+                        "Location",
+                        String.format(
+                            "/v2/%s/blobs/%s",
+                            name.value(),
+                            digest.string()
+                        )
+                    ),
+                    new Header("Content-Length", "0"),
+                    new DigestHeader(digest)
                 )
             );
         }

--- a/src/test/java/com/artipie/docker/asto/AstoBlobsITCase.java
+++ b/src/test/java/com/artipie/docker/asto/AstoBlobsITCase.java
@@ -46,9 +46,9 @@ final class AstoBlobsITCase {
         final InMemoryStorage storage = new InMemoryStorage();
         final BlobStore blobs = new AstoBlobs(storage);
         final ByteBuffer buf = ByteBuffer.wrap(new byte[]{0x00, 0x01, 0x02, 0x03});
-        final Digest digest = blobs.put(new Content.From(Flowable.fromArray(buf)))
-            .toCompletableFuture().get()
-            .digest();
+        final Digest digest = blobs.put(
+            new Content.From(Flowable.fromArray(buf)), new Digest.Sha256(buf.array())
+        ).toCompletableFuture().get().digest();
         MatcherAssert.assertThat(
             "Digest alg is not correct",
             digest.alg(), Matchers.equalTo("sha256")
@@ -72,9 +72,9 @@ final class AstoBlobsITCase {
     void writeAndReadBlob() throws Exception {
         final BlobStore blobs = new AstoBlobs(new InMemoryStorage());
         final ByteBuffer buf = ByteBuffer.wrap(new byte[] {0x05, 0x06, 0x07, 0x08});
-        final Digest digest = blobs.put(new Content.From(Flowable.fromArray(buf)))
-            .toCompletableFuture().get()
-            .digest();
+        final Digest digest = blobs.put(
+            new Content.From(Flowable.fromArray(buf)), new Digest.Sha256(buf.array())
+        ).toCompletableFuture().get().digest();
         final byte[] read = Flowable.fromPublisher(
             blobs.blob(digest)
                 .toCompletableFuture().get()

--- a/src/test/java/com/artipie/docker/asto/AstoRepoITCase.java
+++ b/src/test/java/com/artipie/docker/asto/AstoRepoITCase.java
@@ -29,6 +29,7 @@ import com.artipie.asto.Content;
 import com.artipie.asto.Remaining;
 import com.artipie.asto.Storage;
 import com.artipie.docker.Blob;
+import com.artipie.docker.Digest;
 import com.artipie.docker.ExampleStorage;
 import com.artipie.docker.Repo;
 import com.artipie.docker.RepoName;
@@ -91,10 +92,12 @@ final class AstoRepoITCase {
 
     @Test
     void shouldReadAddedManifest() {
-        final Blob config = new AstoBlobs(this.storage).put(new Content.From("config".getBytes()))
-            .toCompletableFuture().join();
-        final Blob layer = new AstoBlobs(this.storage).put(new Content.From("layer".getBytes()))
-            .toCompletableFuture().join();
+        final byte[] conf = "config".getBytes();
+        final Blob config = new AstoBlobs(this.storage)
+            .put(new Content.From(conf), new Digest.Sha256(conf)).toCompletableFuture().join();
+        final byte[] lyr = "layer".getBytes();
+        final Blob layer = new AstoBlobs(this.storage)
+            .put(new Content.From(lyr), new Digest.Sha256(lyr)).toCompletableFuture().join();
         final byte[] data = Json.createObjectBuilder()
             .add(
                 "config",

--- a/src/test/java/com/artipie/docker/http/ManifestEntityPutTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityPutTest.java
@@ -27,6 +27,7 @@ import com.artipie.asto.Content;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.docker.Blob;
+import com.artipie.docker.Digest;
 import com.artipie.docker.asto.AstoBlobs;
 import com.artipie.docker.asto.AstoDocker;
 import com.artipie.http.hm.RsHasHeaders;
@@ -122,8 +123,10 @@ class ManifestEntityPutTest {
      * @return Manifest content.
      */
     private Flowable<ByteBuffer> manifest() {
-        final Blob config = new AstoBlobs(this.storage).put(new Content.From("config".getBytes()))
-            .toCompletableFuture().join();
+        final byte[] content = "config".getBytes();
+        final Blob config = new AstoBlobs(this.storage).put(
+            new Content.From(content), new Digest.Sha256(content)
+        ).toCompletableFuture().join();
         final byte[] data = String.format(
             "{\"config\":{\"digest\":\"%s\"},\"layers\":[]}",
             config.digest().string()


### PR DESCRIPTION
For #175 I've added `digest` parameter `BlobStore#put` method and got rid of calculating digest twice. 