### PR TITLE
#167 - Added Layers to Repo

### DIFF
--- a/src/main/java/com/artipie/docker/Layers.java
+++ b/src/main/java/com/artipie/docker/Layers.java
@@ -25,52 +25,30 @@
 package com.artipie.docker;
 
 import com.artipie.asto.Content;
-import com.artipie.docker.manifest.Manifest;
-import com.artipie.docker.ref.ManifestRef;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
  * Docker repository files and metadata.
- * @since 0.1
+ *
+ * @since 0.3
  */
-public interface Repo {
+public interface Layers {
 
     /**
-     * Repository layers.
+     * Add layer to repository.
      *
-     * @return Layers.
+     * @param content Layer content.
+     * @param digest Layer digest.
+     * @return Added layer blob.
      */
-    Layers layers();
+    CompletionStage<Blob> put(Content content, Digest digest);
 
     /**
-     * Adds manifest stored as blob.
+     * Find layer by digest.
      *
-     * @param ref Manifest reference.
-     * @param content Manifest content.
-     * @return Added manifest.
-     */
-    CompletionStage<Manifest> addManifest(ManifestRef ref, Content content);
-
-    /**
-     * Resolve docker image manifest file by reference.
-     * @param ref Manifest reference
+     * @param digest Layer digest.
      * @return Flow with manifest data, or empty if absent
      */
-    CompletionStage<Optional<Manifest>> manifest(ManifestRef ref);
-
-    /**
-     * Start new upload.
-     *
-     * @return Upload.
-     */
-    CompletionStage<Upload> startUpload();
-
-    /**
-     * Find upload by UUID.
-     *
-     * @param uuid Upload UUID.
-     * @return Upload.
-     */
-    CompletionStage<Optional<Upload>> upload(String uuid);
+    CompletionStage<Optional<Blob>> get(Digest digest);
 }

--- a/src/main/java/com/artipie/docker/asto/AstoLayers.java
+++ b/src/main/java/com/artipie/docker/asto/AstoLayers.java
@@ -22,55 +22,44 @@
  * SOFTWARE.
  */
 
-package com.artipie.docker;
+package com.artipie.docker.asto;
 
 import com.artipie.asto.Content;
-import com.artipie.docker.manifest.Manifest;
-import com.artipie.docker.ref.ManifestRef;
+import com.artipie.docker.Blob;
+import com.artipie.docker.BlobStore;
+import com.artipie.docker.Digest;
+import com.artipie.docker.Layers;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
- * Docker repository files and metadata.
- * @since 0.1
+ * Asto implementation of {@link Layers}.
+ *
+ * @since 0.3
  */
-public interface Repo {
+public final class AstoLayers implements Layers {
 
     /**
-     * Repository layers.
+     * Blobs storage.
+     */
+    private final BlobStore blobs;
+
+    /**
+     * Ctor.
      *
-     * @return Layers.
+     * @param blobs Blobs storage.
      */
-    Layers layers();
+    public AstoLayers(final BlobStore blobs) {
+        this.blobs = blobs;
+    }
 
-    /**
-     * Adds manifest stored as blob.
-     *
-     * @param ref Manifest reference.
-     * @param content Manifest content.
-     * @return Added manifest.
-     */
-    CompletionStage<Manifest> addManifest(ManifestRef ref, Content content);
+    @Override
+    public CompletionStage<Blob> put(final Content content, final Digest digest) {
+        return this.blobs.put(content, digest);
+    }
 
-    /**
-     * Resolve docker image manifest file by reference.
-     * @param ref Manifest reference
-     * @return Flow with manifest data, or empty if absent
-     */
-    CompletionStage<Optional<Manifest>> manifest(ManifestRef ref);
-
-    /**
-     * Start new upload.
-     *
-     * @return Upload.
-     */
-    CompletionStage<Upload> startUpload();
-
-    /**
-     * Find upload by UUID.
-     *
-     * @param uuid Upload UUID.
-     * @return Upload.
-     */
-    CompletionStage<Optional<Upload>> upload(String uuid);
+    @Override
+    public CompletionStage<Optional<Blob>> get(final Digest digest) {
+        return this.blobs.blob(digest);
+    }
 }

--- a/src/main/java/com/artipie/docker/asto/AstoRepo.java
+++ b/src/main/java/com/artipie/docker/asto/AstoRepo.java
@@ -29,6 +29,7 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.docker.BlobStore;
 import com.artipie.docker.Digest;
+import com.artipie.docker.Layers;
 import com.artipie.docker.Repo;
 import com.artipie.docker.RepoName;
 import com.artipie.docker.Upload;
@@ -78,6 +79,11 @@ public final class AstoRepo implements Repo {
         this.asto = asto;
         this.blobs = blobs;
         this.name = name;
+    }
+
+    @Override
+    public Layers layers() {
+        return new AstoLayers(this.blobs);
     }
 
     @Override

--- a/src/test/java/com/artipie/docker/asto/AstoLayersTest.java
+++ b/src/test/java/com/artipie/docker/asto/AstoLayersTest.java
@@ -23,14 +23,12 @@
  */
 package com.artipie.docker.asto;
 
-import com.artipie.asto.Concatenation;
 import com.artipie.asto.Content;
-import com.artipie.asto.Remaining;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.docker.Blob;
 import com.artipie.docker.Digest;
 import com.artipie.docker.Layers;
-import hu.akarnokd.rxjava2.interop.SingleInterop;
+import com.artipie.docker.misc.ByteBufPublisher;
 import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -92,11 +90,8 @@ final class AstoLayersTest {
     }
 
     private static byte[] bytes(final Blob blob) {
-        return new Concatenation(blob.content().toCompletableFuture().join())
-            .single()
-            .map(Remaining::new)
-            .map(Remaining::bytes)
-            .to(SingleInterop.get())
+        return new ByteBufPublisher(blob.content().toCompletableFuture().join())
+            .bytes()
             .toCompletableFuture().join();
     }
 }

--- a/src/test/java/com/artipie/docker/asto/AstoLayersTest.java
+++ b/src/test/java/com/artipie/docker/asto/AstoLayersTest.java
@@ -1,0 +1,102 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.asto;
+
+import com.artipie.asto.Concatenation;
+import com.artipie.asto.Content;
+import com.artipie.asto.Remaining;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.docker.Blob;
+import com.artipie.docker.Digest;
+import com.artipie.docker.Layers;
+import hu.akarnokd.rxjava2.interop.SingleInterop;
+import java.util.Optional;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link AstoLayers}.
+ *
+ * @since 0.3
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+final class AstoLayersTest {
+
+    /**
+     * Blobs storage.
+     */
+    private AstoBlobs blobs;
+
+    /**
+     * Layers tested.
+     */
+    private Layers layers;
+
+    @BeforeEach
+    void setUp() {
+        final InMemoryStorage storage = new InMemoryStorage();
+        this.blobs = new AstoBlobs(storage);
+        this.layers = new AstoLayers(this.blobs);
+    }
+
+    @Test
+    void shouldAddLayer() {
+        final byte[] data = "data".getBytes();
+        final Digest digest = this.layers.put(new Content.From(data), new Digest.Sha256(data))
+            .toCompletableFuture().join().digest();
+        final Optional<Blob> found = this.blobs.blob(digest).toCompletableFuture().join();
+        MatcherAssert.assertThat(found.isPresent(), new IsEqual<>(true));
+        MatcherAssert.assertThat(bytes(found.get()), new IsEqual<>(data));
+    }
+
+    @Test
+    void shouldReadExistingLayer() {
+        final byte[] data = "content".getBytes();
+        final Digest digest = this.blobs.put(new Content.From(data), new Digest.Sha256(data))
+            .toCompletableFuture().join().digest();
+        final Optional<Blob> found = this.layers.get(digest).toCompletableFuture().join();
+        MatcherAssert.assertThat(found.isPresent(), new IsEqual<>(true));
+        MatcherAssert.assertThat(found.get().digest(), new IsEqual<>(digest));
+        MatcherAssert.assertThat(bytes(found.get()), new IsEqual<>(data));
+    }
+
+    @Test
+    void shouldReadAbsentLayer() {
+        final Optional<Blob> found = this.layers.get(
+            new Digest.Sha256("0123456789012345678901234567890123456789012345678901234567890123")
+        ).toCompletableFuture().join();
+        MatcherAssert.assertThat(found.isPresent(), new IsEqual<>(false));
+    }
+
+    private static byte[] bytes(final Blob blob) {
+        return new Concatenation(blob.content().toCompletableFuture().join())
+            .single()
+            .map(Remaining::new)
+            .map(Remaining::bytes)
+            .to(SingleInterop.get())
+            .toCompletableFuture().join();
+    }
+}

--- a/src/test/java/com/artipie/docker/asto/AstoRepoTest.java
+++ b/src/test/java/com/artipie/docker/asto/AstoRepoTest.java
@@ -21,56 +21,39 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package com.artipie.docker.asto;
 
-package com.artipie.docker;
-
-import com.artipie.asto.Content;
-import com.artipie.docker.manifest.Manifest;
-import com.artipie.docker.ref.ManifestRef;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.docker.Repo;
+import com.artipie.docker.RepoName;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
- * Docker repository files and metadata.
- * @since 0.1
+ * Tests for {@link AstoRepo}.
+ *
+ * @since 0.3
  */
-public interface Repo {
+final class AstoRepoTest {
 
     /**
-     * Repository layers.
-     *
-     * @return Layers.
+     * Layers tested.
      */
-    Layers layers();
+    private Repo repo;
 
-    /**
-     * Adds manifest stored as blob.
-     *
-     * @param ref Manifest reference.
-     * @param content Manifest content.
-     * @return Added manifest.
-     */
-    CompletionStage<Manifest> addManifest(ManifestRef ref, Content content);
+    @BeforeEach
+    void setUp() {
+        final InMemoryStorage storage = new InMemoryStorage();
+        this.repo = new AstoRepo(storage, new AstoBlobs(storage), new RepoName.Valid("test"));
+    }
 
-    /**
-     * Resolve docker image manifest file by reference.
-     * @param ref Manifest reference
-     * @return Flow with manifest data, or empty if absent
-     */
-    CompletionStage<Optional<Manifest>> manifest(ManifestRef ref);
-
-    /**
-     * Start new upload.
-     *
-     * @return Upload.
-     */
-    CompletionStage<Upload> startUpload();
-
-    /**
-     * Find upload by UUID.
-     *
-     * @param uuid Upload UUID.
-     * @return Upload.
-     */
-    CompletionStage<Optional<Upload>> upload(String uuid);
+    @Test
+    void shouldCreateAstoLayers() {
+        MatcherAssert.assertThat(
+            this.repo.layers(),
+            Matchers.instanceOf(AstoLayers.class)
+        );
+    }
 }


### PR DESCRIPTION
Part of #167 
Added `Layers` to `Repo` and `AstoLayers` implementation simply delegating all calls to `AstoBlobs`.
This is needed to remove direct access to `BlobStore` from slices.