### PR TITLE
#182 - replace Concatenation usages with ByteBufPublisher

### DIFF
--- a/src/main/java/com/artipie/docker/misc/ByteBufPublisher.java
+++ b/src/main/java/com/artipie/docker/misc/ByteBufPublisher.java
@@ -37,8 +37,6 @@ import org.reactivestreams.Publisher;
  * Using this class keep in mind that it reads ByteBuffer from publisher into memory and is not
  * suitable for large content.
  * @since 0.3
- * @todo #176:30min Find all `Concatenation` usages in the project (mostly it's used in tests) and
- *  replace them with this class usages.
  */
 public final class ByteBufPublisher {
 

--- a/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
+++ b/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
@@ -23,10 +23,9 @@
  */
 package com.artipie.docker.manifest;
 
-import com.artipie.asto.Concatenation;
 import com.artipie.asto.Content;
-import com.artipie.asto.Remaining;
 import com.artipie.docker.Digest;
+import com.artipie.docker.misc.ByteBufPublisher;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
@@ -182,7 +181,7 @@ class JsonManifestTest {
             new Content.From(data)
         );
         MatcherAssert.assertThat(
-            new Remaining(new Concatenation(manifest.content()).single().blockingGet()).bytes(),
+            new ByteBufPublisher(manifest.content()).bytes().toCompletableFuture().join(),
             new IsEqual<>(data)
         );
     }


### PR DESCRIPTION
For #182 I've replaced all `Concatenation` usages with `ByteBufPublisher`.