### PR TITLE
#167 - Removed BlobStore from Docker

### DIFF
--- a/src/main/java/com/artipie/docker/Blob.java
+++ b/src/main/java/com/artipie/docker/Blob.java
@@ -27,7 +27,7 @@ import com.artipie.asto.Content;
 import java.util.concurrent.CompletionStage;
 
 /**
- * Blob stored in {@link BlobStore}.
+ * Blob stored in repository.
  *
  * @since 0.2
  */

--- a/src/main/java/com/artipie/docker/Docker.java
+++ b/src/main/java/com/artipie/docker/Docker.java
@@ -37,10 +37,4 @@ public interface Docker {
      * @return Repository object
      */
     Repo repo(RepoName name);
-
-    /**
-     * Docker blob store.
-     * @return Blob store for this registry
-     */
-    BlobStore blobStore();
 }

--- a/src/main/java/com/artipie/docker/asto/AstoBlobs.java
+++ b/src/main/java/com/artipie/docker/asto/AstoBlobs.java
@@ -28,7 +28,6 @@ import com.artipie.asto.Content;
 import com.artipie.asto.Storage;
 import com.artipie.asto.fs.RxFile;
 import com.artipie.docker.Blob;
-import com.artipie.docker.BlobStore;
 import com.artipie.docker.Digest;
 import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Completable;
@@ -54,7 +53,7 @@ import java.util.concurrent.CompletionStage;
  * @checkstyle ReturnCountCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class AstoBlobs implements BlobStore {
+final class AstoBlobs implements BlobStore {
 
     /**
      * Vert.x file system used for temporary files.
@@ -70,7 +69,7 @@ public final class AstoBlobs implements BlobStore {
      * Ctor.
      * @param asto Storage
      */
-    public AstoBlobs(final Storage asto) {
+    AstoBlobs(final Storage asto) {
         this.asto = asto;
     }
 

--- a/src/main/java/com/artipie/docker/asto/AstoDocker.java
+++ b/src/main/java/com/artipie/docker/asto/AstoDocker.java
@@ -25,7 +25,6 @@
 package com.artipie.docker.asto;
 
 import com.artipie.asto.Storage;
-import com.artipie.docker.BlobStore;
 import com.artipie.docker.Docker;
 import com.artipie.docker.Repo;
 import com.artipie.docker.RepoName;
@@ -51,11 +50,6 @@ public final class AstoDocker implements Docker {
 
     @Override
     public Repo repo(final RepoName name) {
-        return new AstoRepo(this.asto, this.blobStore(), name);
-    }
-
-    @Override
-    public BlobStore blobStore() {
-        return new AstoBlobs(this.asto);
+        return new AstoRepo(this.asto, new AstoBlobs(this.asto), name);
     }
 }

--- a/src/main/java/com/artipie/docker/asto/AstoLayers.java
+++ b/src/main/java/com/artipie/docker/asto/AstoLayers.java
@@ -26,7 +26,6 @@ package com.artipie.docker.asto;
 
 import com.artipie.asto.Content;
 import com.artipie.docker.Blob;
-import com.artipie.docker.BlobStore;
 import com.artipie.docker.Digest;
 import com.artipie.docker.Layers;
 import java.util.Optional;

--- a/src/main/java/com/artipie/docker/asto/AstoManifests.java
+++ b/src/main/java/com/artipie/docker/asto/AstoManifests.java
@@ -26,7 +26,6 @@ package com.artipie.docker.asto;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
-import com.artipie.docker.BlobStore;
 import com.artipie.docker.Digest;
 import com.artipie.docker.Manifests;
 import com.artipie.docker.RepoName;

--- a/src/main/java/com/artipie/docker/asto/AstoRepo.java
+++ b/src/main/java/com/artipie/docker/asto/AstoRepo.java
@@ -25,7 +25,6 @@
 package com.artipie.docker.asto;
 
 import com.artipie.asto.Storage;
-import com.artipie.docker.BlobStore;
 import com.artipie.docker.Layers;
 import com.artipie.docker.Manifests;
 import com.artipie.docker.Repo;

--- a/src/main/java/com/artipie/docker/asto/BlobStore.java
+++ b/src/main/java/com/artipie/docker/asto/BlobStore.java
@@ -22,9 +22,11 @@
  * SOFTWARE.
  */
 
-package com.artipie.docker;
+package com.artipie.docker.asto;
 
 import com.artipie.asto.Content;
+import com.artipie.docker.Blob;
+import com.artipie.docker.Digest;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
@@ -32,7 +34,7 @@ import java.util.concurrent.CompletionStage;
  * Docker registry blob store.
  * @since 0.1
  */
-public interface BlobStore {
+interface BlobStore {
 
     /**
      * Load blob by digest.

--- a/src/test/java/com/artipie/docker/asto/AstoBlobsITCase.java
+++ b/src/test/java/com/artipie/docker/asto/AstoBlobsITCase.java
@@ -27,7 +27,6 @@ import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
-import com.artipie.docker.BlobStore;
 import com.artipie.docker.Digest;
 import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
@@ -44,7 +43,7 @@ final class AstoBlobsITCase {
     @Test
     void saveBlobDataAtCorrectPath() throws Exception {
         final InMemoryStorage storage = new InMemoryStorage();
-        final BlobStore blobs = new AstoBlobs(storage);
+        final AstoBlobs blobs = new AstoBlobs(storage);
         final ByteBuffer buf = ByteBuffer.wrap(new byte[]{0x00, 0x01, 0x02, 0x03});
         final Digest digest = blobs.put(
             new Content.From(Flowable.fromArray(buf)), new Digest.Sha256(buf.array())
@@ -70,7 +69,7 @@ final class AstoBlobsITCase {
 
     @Test
     void writeAndReadBlob() throws Exception {
-        final BlobStore blobs = new AstoBlobs(new InMemoryStorage());
+        final AstoBlobs blobs = new AstoBlobs(new InMemoryStorage());
         final ByteBuffer buf = ByteBuffer.wrap(new byte[] {0x05, 0x06, 0x07, 0x08});
         final Digest digest = blobs.put(
             new Content.From(Flowable.fromArray(buf)), new Digest.Sha256(buf.array())
@@ -86,7 +85,7 @@ final class AstoBlobsITCase {
 
     @Test
     void readAbsentBlob() throws Exception {
-        final BlobStore blobs = new AstoBlobs(new InMemoryStorage());
+        final AstoBlobs blobs = new AstoBlobs(new InMemoryStorage());
         final Digest digest = new Digest.Sha256(
             "0123456789012345678901234567890123456789012345678901234567890123"
         );

--- a/src/test/java/com/artipie/docker/asto/AstoDockerTest.java
+++ b/src/test/java/com/artipie/docker/asto/AstoDockerTest.java
@@ -42,12 +42,4 @@ final class AstoDockerTest {
             Matchers.instanceOf(AstoRepo.class)
         );
     }
-
-    @Test
-    void createsAstoBlobStore() {
-        MatcherAssert.assertThat(
-            new AstoDocker(new InMemoryStorage()).blobStore(),
-            Matchers.instanceOf(AstoBlobs.class)
-        );
-    }
 }


### PR DESCRIPTION
Closes #167 
Removed BlobStore from Docker, moved the interface to `asto` package, because it is only used there