### PR TITLE
#189 - multipart name in UploadEntity

### DIFF
--- a/src/main/java/com/artipie/docker/http/UploadEntity.java
+++ b/src/main/java/com/artipie/docker/http/UploadEntity.java
@@ -61,7 +61,7 @@ public final class UploadEntity {
      * RegEx pattern for path.
      */
     public static final Pattern PATH = Pattern.compile(
-        "^/v2/(?<name>[^/]*)/blobs/uploads/(?<uuid>.*)$"
+        "^/v2/(?<name>([a-z0-9]+([._-]?[a-z0-9]+)*/?)+)/blobs/uploads/(?<uuid>.*)$"
     );
 
     /**


### PR DESCRIPTION
Part of #189 - I've updated regexp in `UploadEntity` to support multipart names and added tests. 