### PR TITLE
#170 - Added ManifestPath for proxy

### DIFF
--- a/src/main/java/com/artipie/docker/proxy/ManifestPath.java
+++ b/src/main/java/com/artipie/docker/proxy/ManifestPath.java
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.proxy;
+
+import com.artipie.docker.RepoName;
+import com.artipie.docker.ref.ManifestRef;
+
+/**
+ * Path to manifest resource.
+ *
+ * @since 0.3
+ */
+final class ManifestPath {
+
+    /**
+     * Repository name.
+     */
+    private final RepoName name;
+
+    /**
+     * Manifest reference.
+     */
+    private final ManifestRef ref;
+
+    /**
+     * Ctor.
+     *
+     * @param name Repository name.
+     * @param ref Manifest reference.
+     */
+    ManifestPath(final RepoName name, final ManifestRef ref) {
+        this.name = name;
+        this.ref = ref;
+    }
+
+    /**
+     * Build path string.
+     *
+     * @return Path string.
+     */
+    public String string() {
+        return String.format("/v2/%s/manifests/%s", this.name.value(), this.ref.string());
+    }
+}

--- a/src/test/java/com/artipie/docker/proxy/ManifestPathTest.java
+++ b/src/test/java/com/artipie/docker/proxy/ManifestPathTest.java
@@ -1,0 +1,50 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.proxy;
+
+import com.artipie.docker.RepoName;
+import com.artipie.docker.ref.ManifestRef;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ManifestPath}.
+ *
+ * @since 0.3
+ */
+class ManifestPathTest {
+
+    @Test
+    void shouldBuildPathString() {
+        final ManifestPath path = new ManifestPath(
+            new RepoName.Valid("some/image"),
+            new ManifestRef.FromString("my-ref")
+        );
+        MatcherAssert.assertThat(
+            path.string(),
+            new IsEqual<>("/v2/some/image/manifests/my-ref")
+        );
+    }
+}


### PR DESCRIPTION
Part of #170
Added ManifestPath representing HTTP path to manifest by repo name and reference in remote Docker registry