### PR TITLE
#206 - Fixed performance issue with UploadEntity.PATH RegEx

### DIFF
--- a/src/main/java/com/artipie/docker/http/UploadEntity.java
+++ b/src/main/java/com/artipie/docker/http/UploadEntity.java
@@ -61,7 +61,7 @@ public final class UploadEntity {
      * RegEx pattern for path.
      */
     public static final Pattern PATH = Pattern.compile(
-        "^/v2/(?<name>([a-z0-9]+([._-]?[a-z0-9]+)*/?)+)/blobs/uploads/(?<uuid>.*)$"
+        "^/v2/(?<name>.*)/blobs/uploads/(?<uuid>.*)$"
     );
 
     /**

--- a/src/test/java/com/artipie/docker/http/UploadEntityRequestTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityRequestTest.java
@@ -63,9 +63,16 @@ class UploadEntityRequestTest {
     @Test
     void shouldReadUuid() {
         final UploadEntity.Request request = new UploadEntity.Request(
-            new RequestLine("PATCH", "/v2/my-repo/blobs/uploads/123-abc", "HTTP/1.1").toString()
+            new RequestLine(
+                "PATCH",
+                "/v2/my-repo/blobs/uploads/a9e48d2a-c939-441d-bb53-b3ad9ab67709",
+                "HTTP/1.1"
+            ).toString()
         );
-        MatcherAssert.assertThat(request.uuid(), new IsEqual<>("123-abc"));
+        MatcherAssert.assertThat(
+            request.uuid(),
+            new IsEqual<>("a9e48d2a-c939-441d-bb53-b3ad9ab67709")
+        );
     }
 
     @Test


### PR DESCRIPTION
Closes #206 
Simplified UploadEntity.PATH pattern, so it runs fast and still matches expected strings