### PR TITLE
#189 - composite repo name in ManifestEntity

### DIFF
--- a/src/main/java/com/artipie/docker/http/UploadEntity.java
+++ b/src/main/java/com/artipie/docker/http/UploadEntity.java
@@ -28,6 +28,7 @@ import com.artipie.docker.Docker;
 import com.artipie.docker.Repo;
 import com.artipie.docker.RepoName;
 import com.artipie.docker.misc.DigestFromContent;
+import com.artipie.docker.misc.RqByRegex;
 import com.artipie.http.Connection;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
@@ -326,7 +327,9 @@ public final class UploadEntity {
          * @return Repository name.
          */
         RepoName name() {
-            return new RepoName.Valid(this.path().group("name"));
+            return new RepoName.Valid(
+                new RqByRegex(this.line, ManifestEntity.PATH).path().group("name")
+            );
         }
 
         /**
@@ -335,7 +338,7 @@ public final class UploadEntity {
          * @return Upload UUID.
          */
         String uuid() {
-            return this.path().group("uuid");
+            return new RqByRegex(this.line, ManifestEntity.PATH).path().group("uuid");
         }
 
         /**
@@ -353,20 +356,6 @@ public final class UploadEntity {
                 throw new IllegalStateException(String.format("Unexpected query: %s", query));
             }
             return new Digest.FromString(matcher.group("digest"));
-        }
-
-        /**
-         * Matches request path by RegEx pattern.
-         *
-         * @return Path matcher.
-         */
-        private Matcher path() {
-            final String path = new RequestLineFrom(this.line).uri().getPath();
-            final Matcher matcher = PATH.matcher(path);
-            if (!matcher.matches()) {
-                throw new IllegalStateException(String.format("Unexpected path: %s", path));
-            }
-            return matcher;
         }
     }
 

--- a/src/main/java/com/artipie/docker/http/UploadEntity.java
+++ b/src/main/java/com/artipie/docker/http/UploadEntity.java
@@ -328,7 +328,7 @@ public final class UploadEntity {
          */
         RepoName name() {
             return new RepoName.Valid(
-                new RqByRegex(this.line, ManifestEntity.PATH).path().group("name")
+                new RqByRegex(this.line, UploadEntity.PATH).path().group("name")
             );
         }
 
@@ -338,7 +338,7 @@ public final class UploadEntity {
          * @return Upload UUID.
          */
         String uuid() {
-            return new RqByRegex(this.line, ManifestEntity.PATH).path().group("uuid");
+            return new RqByRegex(this.line, UploadEntity.PATH).path().group("uuid");
         }
 
         /**

--- a/src/test/java/com/artipie/docker/http/ManifestEntityRequestTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityRequestTest.java
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.http;
+
+import com.artipie.http.rq.RequestLine;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link ManifestEntity.Request}.
+ * @since 0.4
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class ManifestEntityRequestTest {
+
+    @Test
+    void shouldReadName() {
+        final ManifestEntity.Request request = new ManifestEntity.Request(
+            new RequestLine("GET", "/v2/my-repo/manifests/3", "HTTP/1.1").toString()
+        );
+        MatcherAssert.assertThat(request.name().value(), new IsEqual<>("my-repo"));
+    }
+
+    @Test
+    void shouldReadReference() {
+        final ManifestEntity.Request request = new ManifestEntity.Request(
+            new RequestLine("GET", "/v2/my-repo/manifests/sha256:123abc", "HTTP/1.1").toString()
+        );
+        MatcherAssert.assertThat(request.reference().string(), new IsEqual<>("sha256:123abc"));
+    }
+
+    @Test
+    void shouldReadCompositeName() {
+        final String name = "zero-one/two.three/four_five";
+        MatcherAssert.assertThat(
+            new ManifestEntity.Request(
+                new RequestLine(
+                    "HEAD", String.format("/v2/%s/manifests/sha256:234434df", name), "HTTP/1.1"
+                ).toString()
+            ).name().value(),
+            new IsEqual<>(name)
+        );
+    }
+
+}

--- a/src/test/java/com/artipie/docker/http/UploadEntityRequestTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityRequestTest.java
@@ -91,7 +91,7 @@ class UploadEntityRequestTest {
     void shouldThrowExceptionOnInvalidPath() {
         MatcherAssert.assertThat(
             Assertions.assertThrows(
-                IllegalStateException.class,
+                IllegalArgumentException.class,
                 () -> new UploadEntity.Request(
                     new RequestLine(
                         "PUT",


### PR DESCRIPTION
For #189 I've used `RqByRegex` in `UploadEntity`, made `ManifestEntity` work with composite repo names.