### PR TITLE
#215 - Manifests S3 compatibility issues fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,11 +105,6 @@ SOFTWARE.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <scope>test</scope>

--- a/src/main/java/com/artipie/docker/asto/AstoBlobs.java
+++ b/src/main/java/com/artipie/docker/asto/AstoBlobs.java
@@ -25,6 +25,7 @@
 package com.artipie.docker.asto;
 
 import com.artipie.asto.Content;
+import com.artipie.asto.Remaining;
 import com.artipie.asto.Storage;
 import com.artipie.asto.fs.RxFile;
 import com.artipie.docker.Blob;
@@ -34,6 +35,7 @@ import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -95,11 +97,8 @@ final class AstoBlobs implements BlobStore {
         return Flowable.fromPublisher(blob)
             .flatMapCompletable(
                 buf -> Completable.fromAction(
-                    () -> {
-                        while (buf.hasRemaining()) {
-                            out.write(buf);
-                        }
-                    })
+                    () -> out.write(ByteBuffer.wrap(new Remaining(buf, true).bytes()))
+                )
             )
             .doOnTerminate(out::close)
             .andThen(Single.just(out))


### PR DESCRIPTION
Closes #215 
Fixed S3 compatibility issues with manifest PUT and GET operations.
Fixed issue with `AstoBlobs` class corrupting incoming buffers.