### PR TITLE
#170 - Reading DigestHeader from headers

### DIFF
--- a/src/main/java/com/artipie/docker/http/DigestHeader.java
+++ b/src/main/java/com/artipie/docker/http/DigestHeader.java
@@ -24,8 +24,9 @@
 package com.artipie.docker.http;
 
 import com.artipie.docker.Digest;
+import com.artipie.http.Headers;
+import com.artipie.http.rq.RqHeaders;
 import com.artipie.http.rs.Header;
-import java.util.Map;
 
 /**
  * Docker-Content-Digest header.
@@ -33,12 +34,12 @@ import java.util.Map;
  *
  * @since 0.2
  */
-final class DigestHeader implements Map.Entry<String, String> {
+public final class DigestHeader extends Header.Wrap {
 
     /**
-     * Header delegate.
+     * Header name.
      */
-    private final Header delegate;
+    private static final String NAME = "Docker-Content-Digest";
 
     /**
      * Ctor.
@@ -46,36 +47,33 @@ final class DigestHeader implements Map.Entry<String, String> {
      * @param digest Digest value.
      */
     DigestHeader(final Digest digest) {
-        this.delegate = new Header("Docker-Content-Digest", digest.string());
+        this(digest.string());
     }
 
-    @Override
-    public String getKey() {
-        return this.delegate.getKey();
+    /**
+     * Ctor.
+     *
+     * @param headers Headers to extract header from.
+     */
+    public DigestHeader(final Headers headers) {
+        this(new RqHeaders.Single(headers, DigestHeader.NAME).asString());
     }
 
-    @Override
-    public String getValue() {
-        return this.delegate.getValue();
+    /**
+     * Ctor.
+     *
+     * @param digest Digest value.
+     */
+    private DigestHeader(final String digest) {
+        super(new Header(DigestHeader.NAME, digest));
     }
 
-    @Override
-    public String setValue(final String value) {
-        throw new UnsupportedOperationException("Value cannot be modified");
-    }
-
-    @Override
-    public boolean equals(final Object that) {
-        return this.delegate.equals(that);
-    }
-
-    @Override
-    public int hashCode() {
-        return this.delegate.hashCode();
-    }
-
-    @Override
-    public String toString() {
-        return this.delegate.toString();
+    /**
+     * Read header as numeric value.
+     *
+     * @return Header value.
+     */
+    public Digest value() {
+        return new Digest.FromString(this.getValue());
     }
 }

--- a/src/test/java/com/artipie/docker/http/DigestHeaderTest.java
+++ b/src/test/java/com/artipie/docker/http/DigestHeaderTest.java
@@ -24,8 +24,11 @@
 package com.artipie.docker.http;
 
 import com.artipie.docker.Digest;
+import com.artipie.http.Headers;
+import com.artipie.http.rs.Header;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -49,6 +52,27 @@ public final class DigestHeaderTest {
         MatcherAssert.assertThat(
             header.getValue(),
             new IsEqual<>("sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b")
+        );
+    }
+
+    @Test
+    void shouldExtractValueFromHeaders() {
+        final String digest = "sha256:123";
+        final DigestHeader header = new DigestHeader(
+            new Headers.From(
+                new Header("Content-Type", "application/octet-stream"),
+                new Header("docker-content-digest", digest),
+                new Header("X-Something", "Some Value")
+            )
+        );
+        MatcherAssert.assertThat(header.value().string(), new IsEqual<>(digest));
+    }
+
+    @Test
+    void shouldFailToExtractValueFromEmptyHeaders() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new DigestHeader(Headers.EMPTY).value()
         );
     }
 }


### PR DESCRIPTION
Part of #170 
Reading DigestHeader from headers. Will be used to extract digest of manifest from remote registry response.