### PR TITLE
#170 - ProxyBlob.size() implementation

### DIFF
--- a/src/main/java/com/artipie/docker/proxy/ProxyBlob.java
+++ b/src/main/java/com/artipie/docker/proxy/ProxyBlob.java
@@ -63,20 +63,29 @@ public final class ProxyBlob implements Blob {
     private final Digest dig;
 
     /**
+     * Blob size.
+     */
+    private final long bsize;
+
+    /**
      * Ctor.
      *
      * @param remote Remote repository.
      * @param name Repository name.
      * @param dig Blob digest.
+     * @param size Blob size.
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     public ProxyBlob(
         final Slice remote,
         final RepoName name,
-        final Digest dig
+        final Digest dig,
+        final long size
     ) {
         this.remote = remote;
         this.name = name;
         this.dig = dig;
+        this.bsize = size;
     }
 
     @Override
@@ -86,7 +95,7 @@ public final class ProxyBlob implements Blob {
 
     @Override
     public CompletionStage<Long> size() {
-        throw new UnsupportedOperationException();
+        return CompletableFuture.completedFuture(this.bsize);
     }
 
     @Override

--- a/src/main/java/com/artipie/docker/proxy/ProxyLayers.java
+++ b/src/main/java/com/artipie/docker/proxy/ProxyLayers.java
@@ -28,6 +28,7 @@ import com.artipie.docker.Blob;
 import com.artipie.docker.Digest;
 import com.artipie.docker.Layers;
 import com.artipie.docker.RepoName;
+import com.artipie.docker.http.ContentLength;
 import com.artipie.http.Headers;
 import com.artipie.http.Slice;
 import com.artipie.http.rq.RequestLine;
@@ -87,7 +88,8 @@ public final class ProxyLayers implements Layers {
             Flowable.empty()
         ).send(
             (status, headers, body) -> {
-                promise.complete(Optional.of(new ProxyBlob(this.remote, this.name, digest)));
+                final long size = new ContentLength(headers).value();
+                promise.complete(Optional.of(new ProxyBlob(this.remote, this.name, digest, size)));
                 return CompletableFuture.allOf();
             }
         ).thenCompose(nothing -> promise);

--- a/src/test/java/com/artipie/docker/proxy/ClientSliceIT.java
+++ b/src/test/java/com/artipie/docker/proxy/ClientSliceIT.java
@@ -71,7 +71,7 @@ class ClientSliceIT {
         final Digest digest = new Digest.Sha256(
             "b71717fef0141577dd1588f2838d9a797e026ca20d95d0a89559a6b6af734c7b"
         );
-        final ProxyBlob blob = new ProxyBlob(this.slice, name, digest);
+        final ProxyBlob blob = new ProxyBlob(this.slice, name, digest, 828L);
         MatcherAssert.assertThat(
             blob.content()
                 .thenApply(DigestFromContent::new)

--- a/src/test/java/com/artipie/docker/proxy/ProxyBlobTest.java
+++ b/src/test/java/com/artipie/docker/proxy/ProxyBlobTest.java
@@ -59,7 +59,8 @@ class ProxyBlobTest {
                 );
             },
             new RepoName.Valid("test"),
-            new Digest.FromString("sha256:123")
+            new Digest.FromString("sha256:123"),
+            data.length
         ).content().toCompletableFuture().join();
         MatcherAssert.assertThat(
             new ByteBufPublisher(content).bytes().toCompletableFuture().join(),
@@ -68,6 +69,23 @@ class ProxyBlobTest {
         MatcherAssert.assertThat(
             content.size(),
             new IsEqual<>(Optional.of((long) data.length))
+        );
+    }
+
+    @Test
+    void shouldReadSize() {
+        final long size = 1235L;
+        final ProxyBlob blob = new ProxyBlob(
+            (line, headers, body) -> {
+                throw new UnsupportedOperationException();
+            },
+            new RepoName.Valid("my/test"),
+            new Digest.FromString("sha256:abc"),
+            size
+        );
+        MatcherAssert.assertThat(
+            blob.size().toCompletableFuture().join(),
+            new IsEqual<>(size)
         );
     }
 }


### PR DESCRIPTION
Part of #170 
Added `ProxyBlob.size()` implementation. Size is received in HEAD response before blob creation