### PR TITLE
#172 - Added CacheDocker and CacheRepo skeleton

### DIFF
--- a/src/main/java/com/artipie/docker/cache/CacheDocker.java
+++ b/src/main/java/com/artipie/docker/cache/CacheDocker.java
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.cache;
+
+import com.artipie.docker.Docker;
+import com.artipie.docker.Repo;
+import com.artipie.docker.RepoName;
+
+/**
+ * Cache {@link Docker} implementation.
+ *
+ * @since 0.3
+ */
+public final class CacheDocker implements Docker {
+
+    /**
+     * Origin repository.
+     */
+    private final Docker origin;
+
+    /**
+     * Cache repository.
+     */
+    private final Docker cache;
+
+    /**
+     * Ctor.
+     *
+     * @param origin Origin repository.
+     * @param cache Cache repository.
+     */
+    public CacheDocker(final Docker origin, final Docker cache) {
+        this.origin = origin;
+        this.cache = cache;
+    }
+
+    @Override
+    public Repo repo(final RepoName name) {
+        return new CacheRepo(this.origin.repo(name), this.cache.repo(name));
+    }
+}

--- a/src/main/java/com/artipie/docker/cache/CacheRepo.java
+++ b/src/main/java/com/artipie/docker/cache/CacheRepo.java
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.cache;
+
+import com.artipie.docker.Layers;
+import com.artipie.docker.Manifests;
+import com.artipie.docker.Repo;
+import com.artipie.docker.Uploads;
+
+/**
+ * Cache implementation of {@link Repo}.
+ *
+ * @since 0.3
+ */
+@SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+public final class CacheRepo implements Repo {
+
+    /**
+     * Origin repository.
+     */
+    private final Repo origin;
+
+    /**
+     * Cache repository.
+     */
+    private final Repo cache;
+
+    /**
+     * Ctor.
+     *
+     * @param origin Origin repository.
+     * @param cache Cache repository.
+     */
+    public CacheRepo(final Repo origin, final Repo cache) {
+        this.origin = origin;
+        this.cache = cache;
+    }
+
+    @Override
+    public Layers layers() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Manifests manifests() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uploads uploads() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/artipie/docker/cache/package-info.java
+++ b/src/main/java/com/artipie/docker/cache/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Cache implementation of docker registry.
+ *
+ * @since 0.3
+ */
+package com.artipie.docker.cache;
+

--- a/src/test/java/com/artipie/docker/cache/CacheDockerTest.java
+++ b/src/test/java/com/artipie/docker/cache/CacheDockerTest.java
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.cache;
+
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.docker.RepoName;
+import com.artipie.docker.asto.AstoDocker;
+import com.artipie.docker.proxy.ProxyDocker;
+import com.artipie.http.rs.StandardRs;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link CacheDocker}.
+ *
+ * @since 0.3
+ */
+final class CacheDockerTest {
+
+    @Test
+    void createsCacheRepo() {
+        final CacheDocker docker = new CacheDocker(
+            new ProxyDocker((line, headers, body) -> StandardRs.EMPTY),
+            new AstoDocker(new InMemoryStorage())
+        );
+        MatcherAssert.assertThat(
+            docker.repo(new RepoName.Simple("test")),
+            new IsInstanceOf(CacheRepo.class)
+        );
+    }
+}

--- a/src/test/java/com/artipie/docker/cache/package-info.java
+++ b/src/test/java/com/artipie/docker/cache/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Tests for cache implementations.
+ *
+ * @since 0.3
+ */
+package com.artipie.docker.cache;


### PR DESCRIPTION
Part of #172
Added `CacheDocker` and `CacheRepo` class without implementation