### PR TITLE
#231 - Checking response status in ProxyManifests.get()

### DIFF
--- a/src/main/java/com/artipie/docker/proxy/ProxyManifests.java
+++ b/src/main/java/com/artipie/docker/proxy/ProxyManifests.java
@@ -24,6 +24,7 @@
 package com.artipie.docker.proxy;
 
 import com.artipie.asto.Content;
+import com.artipie.docker.Digest;
 import com.artipie.docker.Manifests;
 import com.artipie.docker.Repo;
 import com.artipie.docker.RepoName;
@@ -36,6 +37,7 @@ import com.artipie.http.Headers;
 import com.artipie.http.Slice;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -45,10 +47,6 @@ import java.util.concurrent.CompletionStage;
  * Proxy implementation of {@link Repo}.
  *
  * @since 0.3
- * @todo #170:30min Handle response status in `ProxyManifests.get()` method.
- *  When response is received from remote repository the status might be not OK
- *  in case the manifest is missing or some internal error occurred. Manifest should be returned
- *  only if OK status came in response.
  */
 public final class ProxyManifests implements Manifests {
 
@@ -90,19 +88,22 @@ public final class ProxyManifests implements Manifests {
             Headers.EMPTY,
             Flowable.empty()
         ).send(
-            (status, headers, body) -> CompletableFuture.allOf(
-                new ByteBufPublisher(body).bytes()
-                    .thenApply(
-                        bytes -> Optional.<Manifest>of(
-                            new JsonManifest(
-                                new DigestHeader(headers).value(),
-                                new Content.From(bytes)
-                            )
-                        )
-                    )
-                    .thenAccept(promise::complete)
-                    .toCompletableFuture()
-            )
+            (status, headers, body) -> {
+                final CompletionStage<Optional<Manifest>> result;
+                if (status == RsStatus.OK) {
+                    final Digest digest = new DigestHeader(headers).value();
+                    result = new ByteBufPublisher(body).bytes().thenApply(
+                        bytes -> Optional.of(new JsonManifest(digest, new Content.From(bytes)))
+                    );
+                } else if (status == RsStatus.NOT_FOUND) {
+                    result = CompletableFuture.completedFuture(Optional.empty());
+                } else {
+                    throw new IllegalArgumentException(
+                        String.format("Unexpected status: %s", status)
+                    );
+                }
+                return result.thenAccept(promise::complete).toCompletableFuture();
+            }
         ).thenCompose(nothing -> promise);
     }
 }

--- a/src/main/java/com/artipie/docker/proxy/ProxyManifests.java
+++ b/src/main/java/com/artipie/docker/proxy/ProxyManifests.java
@@ -98,8 +98,8 @@ public final class ProxyManifests implements Manifests {
                 } else if (status == RsStatus.NOT_FOUND) {
                     result = CompletableFuture.completedFuture(Optional.empty());
                 } else {
-                    throw new IllegalArgumentException(
-                        String.format("Unexpected status: %s", status)
+                    result = CompletableFuture.failedFuture(
+                        new IllegalArgumentException(String.format("Unexpected status: %s", status))
                     );
                 }
                 return result.thenAccept(promise::complete).toCompletableFuture();

--- a/src/test/java/com/artipie/docker/proxy/ClientSliceIT.java
+++ b/src/test/java/com/artipie/docker/proxy/ClientSliceIT.java
@@ -113,4 +113,20 @@ class ClientSliceIT {
             new IsEqual<>(true)
         );
     }
+
+    @Test
+    void getManifestNotFound() {
+        final RepoName name = new RepoName.Valid("dotnet/core/runtime");
+        final ProxyManifests manifests = new ProxyManifests(this.slice, name);
+        final ManifestRef ref = new ManifestRef.FromDigest(
+            new Digest.FromString(
+                "sha256:0123456789012345678901234567890123456789012345678901234567890123"
+            )
+        );
+        final Optional<Manifest> manifest = manifests.get(ref).toCompletableFuture().join();
+        MatcherAssert.assertThat(
+            manifest.isPresent(),
+            new IsEqual<>(false)
+        );
+    }
 }

--- a/src/test/java/com/artipie/docker/proxy/ProxyManifestsTest.java
+++ b/src/test/java/com/artipie/docker/proxy/ProxyManifestsTest.java
@@ -33,6 +33,7 @@ import com.artipie.docker.ref.ManifestRef;
 import com.artipie.http.Headers;
 import com.artipie.http.rs.RsFull;
 import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.RsWithStatus;
 import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -75,5 +76,19 @@ class ProxyManifestsTest {
             content.size(),
             new IsEqual<>(Optional.of((long) data.length))
         );
+    }
+
+    @Test
+    void shouldGetEmptyWhenNotFound() {
+        final Optional<Manifest> found = new ProxyManifests(
+            (line, headers, body) -> {
+                if (!line.startsWith("GET /v2/my-test/manifests/latest ")) {
+                    throw new IllegalArgumentException();
+                }
+                return new RsWithStatus(RsStatus.NOT_FOUND);
+            },
+            new RepoName.Valid("my-test")
+        ).get(new ManifestRef.FromString("latest")).toCompletableFuture().join();
+        MatcherAssert.assertThat(found.isEmpty(), new IsEqual<>(true));
     }
 }


### PR DESCRIPTION
Closes #231 
Checking HTTP response status in `ProxyManifests.get()`, proper handling of 404 status