### PR TITLE
#129 - simplify Matchers.allOf

### DIFF
--- a/src/test/java/com/artipie/docker/http/BaseEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/BaseEntityGetTest.java
@@ -26,17 +26,13 @@ package com.artipie.docker.http;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.docker.asto.AstoDocker;
 import com.artipie.http.Response;
-import com.artipie.http.hm.RsHasHeaders;
-import com.artipie.http.hm.RsHasStatus;
+import com.artipie.http.hm.ResponseMatcher;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.Header;
-import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
-import java.util.Arrays;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -58,13 +54,8 @@ class BaseEntityGetTest {
         );
         MatcherAssert.assertThat(
             response,
-            new AllOf<>(
-                Arrays.asList(
-                    new RsHasStatus(RsStatus.OK),
-                    new RsHasHeaders(
-                        new Header("Docker-Distribution-API-Version", "registry/2.0")
-                    )
-                )
+            new ResponseMatcher(
+                new Header("Docker-Distribution-API-Version", "registry/2.0")
             )
         );
     }

--- a/src/test/java/com/artipie/docker/http/BlobEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/BlobEntityGetTest.java
@@ -28,18 +28,15 @@ import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.docker.ExampleStorage;
 import com.artipie.docker.asto.AstoDocker;
 import com.artipie.http.Response;
-import com.artipie.http.hm.RsHasBody;
-import com.artipie.http.hm.RsHasHeaders;
+import com.artipie.http.hm.ResponseMatcher;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.Header;
 import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
-import java.util.Arrays;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -84,18 +81,12 @@ class BlobEntityGetTest {
         );
         MatcherAssert.assertThat(
             response,
-            new AllOf<>(
-                Arrays.asList(
-                    new RsHasStatus(RsStatus.OK),
-                    new RsHasHeaders(
-                        new Header("Content-Length", "2803255"),
-                        new Header("Docker-Content-Digest", digest),
-                        new Header("Content-Type", "application/octet-stream")
-                    ),
-                    new RsHasBody(
-                        new BlockingStorage(new ExampleStorage()).value(expected)
-                    )
-                )
+            new ResponseMatcher(
+                RsStatus.OK,
+                new BlockingStorage(new ExampleStorage()).value(expected),
+                new Header("Content-Length", "2803255"),
+                new Header("Docker-Content-Digest", digest),
+                new Header("Content-Type", "application/octet-stream")
             )
         );
     }

--- a/src/test/java/com/artipie/docker/http/ResponseMatcher.java
+++ b/src/test/java/com/artipie/docker/http/ResponseMatcher.java
@@ -24,6 +24,7 @@
 package com.artipie.docker.http;
 
 import com.artipie.http.Response;
+import com.artipie.http.hm.RsHasBody;
 import com.artipie.http.hm.RsHasHeaders;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rs.Header;
@@ -41,6 +42,7 @@ import org.hamcrest.core.AllOf;
  *  com.artipie.docker.http.ManifestEntityGetTest#success(com.artipie.asto.Key)
  *  method.
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class ResponseMatcher extends AllOf<Response> {
 
     /**
@@ -61,4 +63,27 @@ final class ResponseMatcher extends AllOf<Response> {
             )
         );
     }
+
+    /**
+     * Ctor.
+     * @param digest Digest
+     * @param content Content
+     */
+    ResponseMatcher(final String digest, final byte[] content) {
+        super(
+            new ListOf<Matcher<? super Response>>(
+                new RsHasStatus(RsStatus.OK),
+                new RsHasHeaders(
+                    new Header("Content-Length", String.valueOf(content.length)),
+                    new Header(
+                        "Content-Type",
+                        "application/vnd.docker.distribution.manifest.v2+json"
+                    ),
+                    new Header("Docker-Content-Digest", digest)
+                ),
+                new RsHasBody(content)
+            )
+        );
+    }
+
 }

--- a/src/test/java/com/artipie/docker/http/UploadEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityGetTest.java
@@ -30,17 +30,15 @@ import com.artipie.docker.RepoName;
 import com.artipie.docker.Upload;
 import com.artipie.docker.asto.AstoDocker;
 import com.artipie.http.Response;
-import com.artipie.http.hm.RsHasHeaders;
+import com.artipie.http.hm.ResponseMatcher;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.Header;
 import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
-import java.util.Arrays;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -84,15 +82,11 @@ public final class UploadEntityGetTest {
         );
         MatcherAssert.assertThat(
             response,
-            new AllOf<>(
-                Arrays.asList(
-                    new RsHasStatus(RsStatus.NO_CONTENT),
-                    new RsHasHeaders(
-                        new Header("Range", "0-0"),
-                        new Header("Content-Length", "0"),
-                        new Header("Docker-Upload-UUID", upload.uuid())
-                   )
-                )
+            new ResponseMatcher(
+                RsStatus.NO_CONTENT,
+                new Header("Range", "0-0"),
+                new Header("Content-Length", "0"),
+                new Header("Docker-Upload-UUID", upload.uuid())
             )
         );
     }
@@ -113,15 +107,11 @@ public final class UploadEntityGetTest {
         );
         MatcherAssert.assertThat(
             response,
-            new AllOf<>(
-                Arrays.asList(
-                    new RsHasStatus(RsStatus.NO_CONTENT),
-                    new RsHasHeaders(
-                        new Header("Range", "0-0"),
-                        new Header("Content-Length", "0"),
-                        new Header("Docker-Upload-UUID", upload.uuid())
-                    )
-                )
+            new ResponseMatcher(
+                RsStatus.NO_CONTENT,
+                new Header("Range", "0-0"),
+                new Header("Content-Length", "0"),
+                new Header("Docker-Upload-UUID", upload.uuid())
             )
         );
     }
@@ -143,15 +133,11 @@ public final class UploadEntityGetTest {
         );
         MatcherAssert.assertThat(
             get,
-            new AllOf<>(
-                Arrays.asList(
-                    new RsHasStatus(RsStatus.NO_CONTENT),
-                    new RsHasHeaders(
-                        new Header("Range", "0-127"),
-                        new Header("Content-Length", "0"),
-                        new Header("Docker-Upload-UUID", upload.uuid())
-                    )
-                )
+            new ResponseMatcher(
+                RsStatus.NO_CONTENT,
+                new Header("Range", "0-127"),
+                new Header("Content-Length", "0"),
+                new Header("Docker-Upload-UUID", upload.uuid())
             )
         );
     }

--- a/src/test/java/com/artipie/docker/http/UploadEntityPatchTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityPatchTest.java
@@ -29,7 +29,7 @@ import com.artipie.docker.RepoName;
 import com.artipie.docker.Upload;
 import com.artipie.docker.asto.AstoDocker;
 import com.artipie.http.Response;
-import com.artipie.http.hm.RsHasHeaders;
+import com.artipie.http.hm.ResponseMatcher;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
@@ -37,10 +37,8 @@ import com.artipie.http.rs.Header;
 import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -86,16 +84,12 @@ class UploadEntityPatchTest {
         );
         MatcherAssert.assertThat(
             response,
-            new AllOf<>(
-                Arrays.asList(
-                    new RsHasStatus(RsStatus.ACCEPTED),
-                    new RsHasHeaders(
-                        new Header("Location", path),
-                        new Header("Range", String.format("0-%d", data.length - 1)),
-                        new Header("Content-Length", "0"),
-                        new Header("Docker-Upload-UUID", uuid)
-                    )
-                )
+            new ResponseMatcher(
+                RsStatus.ACCEPTED,
+                new Header("Location", path),
+                new Header("Range", String.format("0-%d", data.length - 1)),
+                new Header("Content-Length", "0"),
+                new Header("Docker-Upload-UUID", uuid)
             )
         );
     }


### PR DESCRIPTION
Part of #129 - simplified `Matchers.allOf` usages with `ResponseMatcher`