### PR TITLE
#255 - Added ReadWriteDocker and ReadWriteRepo skeleton

### DIFF
--- a/src/main/java/com/artipie/docker/composite/ReadWriteDocker.java
+++ b/src/main/java/com/artipie/docker/composite/ReadWriteDocker.java
@@ -29,6 +29,10 @@ import com.artipie.docker.RepoName;
 
 /**
  * Read-write {@link Docker} implementation.
+ * It delegates read operation to one {@link Docker} and writes {@link Docker} to another.
+ * This class can be used to create virtual repository
+ * by composing {@link com.artipie.docker.proxy.ProxyDocker}
+ * and {@link com.artipie.docker.asto.AstoDocker}.
  *
  * @since 0.3
  */

--- a/src/main/java/com/artipie/docker/composite/ReadWriteDocker.java
+++ b/src/main/java/com/artipie/docker/composite/ReadWriteDocker.java
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.composite;
+
+import com.artipie.docker.Docker;
+import com.artipie.docker.Repo;
+import com.artipie.docker.RepoName;
+
+/**
+ * Read-write {@link Docker} implementation.
+ *
+ * @since 0.3
+ */
+public final class ReadWriteDocker implements Docker {
+
+    /**
+     * Docker for reading.
+     */
+    private final Docker read;
+
+    /**
+     * Docker for writing.
+     */
+    private final Docker write;
+
+    /**
+     * Ctor.
+     *
+     * @param read Docker for reading.
+     * @param write Docker for writing.
+     */
+    public ReadWriteDocker(final Docker read, final Docker write) {
+        this.read = read;
+        this.write = write;
+    }
+
+    @Override
+    public Repo repo(final RepoName name) {
+        return new ReadWriteRepo(this.read.repo(name), this.write.repo(name));
+    }
+}

--- a/src/main/java/com/artipie/docker/composite/ReadWriteRepo.java
+++ b/src/main/java/com/artipie/docker/composite/ReadWriteRepo.java
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.composite;
+
+import com.artipie.docker.Layers;
+import com.artipie.docker.Manifests;
+import com.artipie.docker.Repo;
+import com.artipie.docker.Uploads;
+
+/**
+ * Read-write {@link Repo} implementation.
+ *
+ * @since 0.3
+ */
+@SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+public final class ReadWriteRepo implements Repo {
+
+    /**
+     * Repository for reading.
+     */
+    private final Repo read;
+
+    /**
+     * Repository for writing.
+     */
+    private final Repo write;
+
+    /**
+     * Ctor.
+     *
+     * @param read Repository for reading.
+     * @param write Repository for writing.
+     */
+    public ReadWriteRepo(final Repo read, final Repo write) {
+        this.read = read;
+        this.write = write;
+    }
+
+    @Override
+    public Layers layers() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Manifests manifests() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uploads uploads() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/artipie/docker/composite/package-info.java
+++ b/src/main/java/com/artipie/docker/composite/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Composite docker registries.
+ *
+ * @since 0.3
+ */
+package com.artipie.docker.composite;
+

--- a/src/test/java/com/artipie/docker/composite/ReadWriteDockerTest.java
+++ b/src/test/java/com/artipie/docker/composite/ReadWriteDockerTest.java
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.composite;
+
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.docker.RepoName;
+import com.artipie.docker.asto.AstoDocker;
+import com.artipie.docker.proxy.ProxyDocker;
+import com.artipie.http.rs.StandardRs;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ReadWriteDocker}.
+ *
+ * @since 0.3
+ */
+final class ReadWriteDockerTest {
+
+    @Test
+    void createsReadWriteRepo() {
+        final ReadWriteDocker docker = new ReadWriteDocker(
+            new ProxyDocker((line, headers, body) -> StandardRs.EMPTY),
+            new AstoDocker(new InMemoryStorage())
+        );
+        MatcherAssert.assertThat(
+            docker.repo(new RepoName.Simple("test")),
+            new IsInstanceOf(ReadWriteRepo.class)
+        );
+    }
+}

--- a/src/test/java/com/artipie/docker/composite/package-info.java
+++ b/src/test/java/com/artipie/docker/composite/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Tests for composite implementations.
+ *
+ * @since 0.3
+ */
+package com.artipie.docker.composite;


### PR DESCRIPTION
Part of #255 
Added `ReadWriteDocker` and `ReadWriteRepo` skeleton as start of support for virtual Docker repository