### PR TITLE
#173 - Added MultiReadDocker and MultiReadRepo skeleton

### DIFF
--- a/src/main/java/com/artipie/docker/composite/MultiReadDocker.java
+++ b/src/main/java/com/artipie/docker/composite/MultiReadDocker.java
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.composite;
+
+import com.artipie.docker.Docker;
+import com.artipie.docker.Repo;
+import com.artipie.docker.RepoName;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Multi-read {@link Docker} implementation.
+ * It delegates all read operations to multiple other {@link Docker} instances.
+ * List of Docker instances is prioritized.
+ * It means that if more then one of repositories contains an image for given name
+ * then image from repository coming first is returned.
+ * Write operations are not supported.
+ * Might be used to join multiple proxy Dockers into single repository.
+ *
+ * @since 0.3
+ */
+public final class MultiReadDocker implements Docker {
+
+    /**
+     * Dockers for reading.
+     */
+    private final List<Docker> dockers;
+
+    /**
+     * Ctor.
+     *
+     * @param dockers Dockers for reading.
+     */
+    public MultiReadDocker(final List<Docker> dockers) {
+        this.dockers = dockers;
+    }
+
+    @Override
+    public Repo repo(final RepoName name) {
+        return new MultiReadRepo(
+            this.dockers.stream().map(docker -> docker.repo(name)).collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/com/artipie/docker/composite/MultiReadRepo.java
+++ b/src/main/java/com/artipie/docker/composite/MultiReadRepo.java
@@ -1,0 +1,68 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.composite;
+
+import com.artipie.docker.Layers;
+import com.artipie.docker.Manifests;
+import com.artipie.docker.Repo;
+import com.artipie.docker.Uploads;
+import java.util.List;
+
+/**
+ * Multi-read {@link Repo} implementation.
+ *
+ * @since 0.3
+ */
+@SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+public final class MultiReadRepo implements Repo {
+
+    /**
+     * Repositories for reading.
+     */
+    private final List<Repo> repos;
+
+    /**
+     * Ctor.
+     *
+     * @param repos Repositories for reading.
+     */
+    public MultiReadRepo(final List<Repo> repos) {
+        this.repos = repos;
+    }
+
+    @Override
+    public Layers layers() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Manifests manifests() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uploads uploads() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/com/artipie/docker/composite/MultiReadDockerTest.java
+++ b/src/test/java/com/artipie/docker/composite/MultiReadDockerTest.java
@@ -1,0 +1,56 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.composite;
+
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.docker.RepoName;
+import com.artipie.docker.asto.AstoDocker;
+import com.artipie.docker.proxy.ProxyDocker;
+import com.artipie.http.rs.StandardRs;
+import java.util.Arrays;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link MultiReadDocker}.
+ *
+ * @since 0.3
+ */
+final class MultiReadDockerTest {
+
+    @Test
+    void createsMultiReadRepo() {
+        final MultiReadDocker docker = new MultiReadDocker(
+            Arrays.asList(
+                new ProxyDocker((line, headers, body) -> StandardRs.EMPTY),
+                new AstoDocker(new InMemoryStorage())
+            )
+        );
+        MatcherAssert.assertThat(
+            docker.repo(new RepoName.Simple("test")),
+            new IsInstanceOf(MultiReadRepo.class)
+        );
+    }
+}


### PR DESCRIPTION
Part of #173 
Added `MultiReadDocker` and `MultiReadRepo` skeleton to support multi-remote proxy