### PR TITLE
#275 - Auth for all read endpoints, auth integration tests enabled

### DIFF
--- a/src/main/java/com/artipie/docker/http/DockerSlice.java
+++ b/src/main/java/com/artipie/docker/http/DockerSlice.java
@@ -91,14 +91,14 @@ public final class DockerSlice extends Slice.Wrap {
                         new RtRule.ByPath(BaseEntity.PATH),
                         new RtRule.ByMethod(RqMethod.GET)
                     ),
-                    new BaseEntity()
+                    authRead(new BaseEntity(), perms, ids)
                 ),
                 new RtRulePath(
                     new RtRule.All(
                         new RtRule.ByPath(ManifestEntity.PATH),
                         new RtRule.ByMethod(RqMethod.HEAD)
                     ),
-                    new ManifestEntity.Head(docker)
+                    authRead(new ManifestEntity.Head(docker), perms, ids)
                 ),
                 new RtRulePath(
                     new RtRule.All(
@@ -119,14 +119,14 @@ public final class DockerSlice extends Slice.Wrap {
                         new RtRule.ByPath(BlobEntity.PATH),
                         new RtRule.ByMethod(RqMethod.HEAD)
                     ),
-                    new BlobEntity.Head(docker)
+                    authRead(new BlobEntity.Head(docker), perms, ids)
                 ),
                 new RtRulePath(
                     new RtRule.All(
                         new RtRule.ByPath(BlobEntity.PATH),
                         new RtRule.ByMethod(RqMethod.GET)
                     ),
-                    new BlobEntity.Get(docker)
+                    authRead(new BlobEntity.Get(docker), perms, ids)
                 ),
                 new RtRulePath(
                     new RtRule.All(
@@ -154,7 +154,7 @@ public final class DockerSlice extends Slice.Wrap {
                         new RtRule.ByPath(UploadEntity.PATH),
                         new RtRule.ByMethod(RqMethod.GET)
                     ),
-                    new UploadEntity.Get(docker)
+                    authRead(new UploadEntity.Get(docker), perms, ids)
                 )
             )
         );

--- a/src/test/java/com/artipie/docker/http/BlobEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/BlobEntityGetTest.java
@@ -28,6 +28,7 @@ import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.docker.ExampleStorage;
 import com.artipie.docker.asto.AstoDocker;
 import com.artipie.http.Response;
+import com.artipie.http.auth.Permissions;
 import com.artipie.http.headers.Header;
 import com.artipie.http.hm.ResponseMatcher;
 import com.artipie.http.hm.RsHasStatus;
@@ -57,7 +58,11 @@ class BlobEntityGetTest {
 
     @BeforeEach
     void setUp() {
-        this.slice = new DockerSlice(new AstoDocker(new ExampleStorage()));
+        this.slice = new DockerSlice(
+            new AstoDocker(new ExampleStorage()),
+            new Permissions.Single(TestAuthentication.USERNAME, DockerSlice.READ),
+            new TestAuthentication()
+        );
     }
 
     @Test
@@ -72,7 +77,7 @@ class BlobEntityGetTest {
                 RqMethod.GET,
                 String.format("/v2/test/blobs/%s", digest)
             ).toString(),
-            Collections.emptyList(),
+            new TestAuthentication.Headers(),
             Flowable.empty()
         );
         final Key expected = new Key.From(
@@ -102,10 +107,22 @@ class BlobEntityGetTest {
                         "sha256:0123456789012345678901234567890123456789012345678901234567890123"
                     )
                 ).toString(),
-                Collections.emptyList(),
+                new TestAuthentication.Headers(),
                 Flowable.empty()
             ),
             new RsHasStatus(RsStatus.NOT_FOUND)
+        );
+    }
+
+    @Test
+    void shouldReturnUnauthorizedWhenNoAuth() {
+        MatcherAssert.assertThat(
+            this.slice.response(
+                new RequestLine(RqMethod.GET, "/v2/test/blobs/sha256:123").toString(),
+                Collections.emptyList(),
+                Flowable.empty()
+            ),
+            new RsHasStatus(RsStatus.UNAUTHORIZED)
         );
     }
 }

--- a/src/test/java/com/artipie/docker/http/BlobEntityHeadTest.java
+++ b/src/test/java/com/artipie/docker/http/BlobEntityHeadTest.java
@@ -26,6 +26,7 @@ package com.artipie.docker.http;
 import com.artipie.docker.ExampleStorage;
 import com.artipie.docker.asto.AstoDocker;
 import com.artipie.http.Response;
+import com.artipie.http.auth.Permissions;
 import com.artipie.http.headers.Header;
 import com.artipie.http.hm.ResponseMatcher;
 import com.artipie.http.hm.RsHasStatus;
@@ -55,7 +56,11 @@ class BlobEntityHeadTest {
 
     @BeforeEach
     void setUp() {
-        this.slice = new DockerSlice(new AstoDocker(new ExampleStorage()));
+        this.slice = new DockerSlice(
+            new AstoDocker(new ExampleStorage()),
+            new Permissions.Single(TestAuthentication.USERNAME, DockerSlice.READ),
+            new TestAuthentication()
+        );
     }
 
     @Test
@@ -70,7 +75,7 @@ class BlobEntityHeadTest {
                 RqMethod.HEAD,
                 String.format("/v2/test/blobs/%s", digest)
             ).toString(),
-            Collections.emptyList(),
+            new TestAuthentication.Headers(),
             Flowable.empty()
         );
         MatcherAssert.assertThat(
@@ -95,10 +100,22 @@ class BlobEntityHeadTest {
                         "sha256:0123456789012345678901234567890123456789012345678901234567890123"
                     )
                 ).toString(),
-                Collections.emptyList(),
+                new TestAuthentication.Headers(),
                 Flowable.empty()
             ),
             new RsHasStatus(RsStatus.NOT_FOUND)
+        );
+    }
+
+    @Test
+    void shouldReturnUnauthorizedWhenNoAuth() {
+        MatcherAssert.assertThat(
+            this.slice.response(
+                new RequestLine(RqMethod.HEAD, "/v2/test/blobs/sha256:123").toString(),
+                Collections.emptyList(),
+                Flowable.empty()
+            ),
+            new RsHasStatus(RsStatus.UNAUTHORIZED)
         );
     }
 }

--- a/src/test/java/com/artipie/docker/http/DockerAuthITCase.java
+++ b/src/test/java/com/artipie/docker/http/DockerAuthITCase.java
@@ -32,7 +32,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -43,7 +42,6 @@ import org.junit.jupiter.api.Test;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @DockerClientSupport
-@Disabled("Auth is not fully implemented")
 final class DockerAuthITCase {
 
     /**


### PR DESCRIPTION
Closes #275 
Auth for all read endpoints, auth integration tests enabled