### PR TITLE
#117 - Unauthorized error returned properly in all endpoints

### DIFF
--- a/src/main/java/com/artipie/docker/http/DockerSlice.java
+++ b/src/main/java/com/artipie/docker/http/DockerSlice.java
@@ -173,10 +173,12 @@ public final class DockerSlice extends Slice.Wrap {
         final Permissions perms,
         final Identities ids
     ) {
-        return new SliceAuth(
-            origin,
-            new Permission.ByName(DockerSlice.READ, perms),
-            ids
+        return new DockerAuthSlice(
+            new SliceAuth(
+                origin,
+                new Permission.ByName(DockerSlice.READ, perms),
+                ids
+            )
         );
     }
 
@@ -193,10 +195,12 @@ public final class DockerSlice extends Slice.Wrap {
         final Permissions perms,
         final Identities ids
     ) {
-        return new SliceAuth(
-            origin,
-            new Permission.ByName(DockerSlice.WRITE, perms),
-            ids
+        return new DockerAuthSlice(
+            new SliceAuth(
+                origin,
+                new Permission.ByName(DockerSlice.WRITE, perms),
+                ids
+            )
         );
     }
 }

--- a/src/test/java/com/artipie/docker/http/BaseEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/BaseEntityGetTest.java
@@ -29,10 +29,8 @@ import com.artipie.http.Response;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.headers.Header;
 import com.artipie.http.hm.ResponseMatcher;
-import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
-import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
@@ -86,7 +84,7 @@ class BaseEntityGetTest {
                 Collections.emptyList(),
                 Flowable.empty()
             ),
-            new RsHasStatus(RsStatus.UNAUTHORIZED)
+            new IsUnauthorizedResponse()
         );
     }
 }

--- a/src/test/java/com/artipie/docker/http/BlobEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/BlobEntityGetTest.java
@@ -31,7 +31,6 @@ import com.artipie.http.Response;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.headers.Header;
 import com.artipie.http.hm.ResponseMatcher;
-import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
@@ -122,7 +121,7 @@ class BlobEntityGetTest {
                 Collections.emptyList(),
                 Flowable.empty()
             ),
-            new RsHasStatus(RsStatus.UNAUTHORIZED)
+            new IsUnauthorizedResponse()
         );
     }
 }

--- a/src/test/java/com/artipie/docker/http/BlobEntityHeadTest.java
+++ b/src/test/java/com/artipie/docker/http/BlobEntityHeadTest.java
@@ -29,7 +29,6 @@ import com.artipie.http.Response;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.headers.Header;
 import com.artipie.http.hm.ResponseMatcher;
-import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
@@ -115,7 +114,7 @@ class BlobEntityHeadTest {
                 Collections.emptyList(),
                 Flowable.empty()
             ),
-            new RsHasStatus(RsStatus.UNAUTHORIZED)
+            new IsUnauthorizedResponse()
         );
     }
 }

--- a/src/test/java/com/artipie/docker/http/DockerAuthSliceTest.java
+++ b/src/test/java/com/artipie/docker/http/DockerAuthSliceTest.java
@@ -72,7 +72,7 @@ public final class DockerAuthSliceTest {
             ),
             new AllOf<>(
                 Arrays.asList(
-                    new IsErrorsResponse(RsStatus.UNAUTHORIZED, "UNAUTHORIZED"),
+                    new IsUnauthorizedResponse(),
                     new RsHasHeaders(new Headers.From(headers, new ContentLength("72")))
                 )
             )

--- a/src/test/java/com/artipie/docker/http/IsUnauthorizedResponse.java
+++ b/src/test/java/com/artipie/docker/http/IsUnauthorizedResponse.java
@@ -1,0 +1,60 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.http;
+
+import com.artipie.http.Response;
+import com.artipie.http.rs.RsStatus;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+/**
+ * Matcher for unauthorized error response.
+ *
+ * @since 0.5
+ */
+public final class IsUnauthorizedResponse extends BaseMatcher<Response> {
+
+    /**
+     * Delegate matcher.
+     */
+    private final Matcher<Response> delegate;
+
+    /**
+     * Ctor.
+     */
+    public IsUnauthorizedResponse() {
+        this.delegate = new IsErrorsResponse(RsStatus.UNAUTHORIZED, "UNAUTHORIZED");
+    }
+
+    @Override
+    public boolean matches(final Object actual) {
+        return this.delegate.matches(actual);
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        this.delegate.describeTo(description);
+    }
+}

--- a/src/test/java/com/artipie/docker/http/ManifestEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityGetTest.java
@@ -149,7 +149,7 @@ class ManifestEntityGetTest {
                 Collections.emptyList(),
                 Flowable.empty()
             ),
-            new RsHasStatus(RsStatus.UNAUTHORIZED)
+            new IsUnauthorizedResponse()
         );
     }
 

--- a/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
@@ -137,7 +137,7 @@ class ManifestEntityHeadTest {
                 Collections.emptyList(),
                 Flowable.empty()
             ),
-            new RsHasStatus(RsStatus.UNAUTHORIZED)
+            new IsUnauthorizedResponse()
         );
     }
 

--- a/src/test/java/com/artipie/docker/http/ManifestEntityPutTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityPutTest.java
@@ -33,7 +33,6 @@ import com.artipie.docker.asto.AstoDocker;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.headers.Header;
 import com.artipie.http.hm.ResponseMatcher;
-import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
@@ -126,7 +125,7 @@ class ManifestEntityPutTest {
                 Collections.emptyList(),
                 Flowable.empty()
             ),
-            new RsHasStatus(RsStatus.UNAUTHORIZED)
+            new IsUnauthorizedResponse()
         );
     }
 

--- a/src/test/java/com/artipie/docker/http/UploadEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityGetTest.java
@@ -33,7 +33,6 @@ import com.artipie.http.Response;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.headers.Header;
 import com.artipie.http.hm.ResponseMatcher;
-import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
@@ -168,7 +167,7 @@ public final class UploadEntityGetTest {
                 Collections.emptyList(),
                 Flowable.empty()
             ),
-            new RsHasStatus(RsStatus.UNAUTHORIZED)
+            new IsUnauthorizedResponse()
         );
     }
 }

--- a/src/test/java/com/artipie/docker/http/UploadEntityPatchTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityPatchTest.java
@@ -32,7 +32,6 @@ import com.artipie.http.Response;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.headers.Header;
 import com.artipie.http.hm.ResponseMatcher;
-import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
@@ -120,7 +119,7 @@ class UploadEntityPatchTest {
                 Collections.emptyList(),
                 Flowable.empty()
             ),
-            new RsHasStatus(RsStatus.UNAUTHORIZED)
+            new IsUnauthorizedResponse()
         );
     }
 }

--- a/src/test/java/com/artipie/docker/http/UploadEntityPostTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityPostTest.java
@@ -29,7 +29,6 @@ import com.artipie.http.Response;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.hm.IsHeader;
 import com.artipie.http.hm.ResponseMatcher;
-import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
@@ -96,7 +95,7 @@ class UploadEntityPostTest {
                 Collections.emptyList(),
                 Flowable.empty()
             ),
-            new RsHasStatus(RsStatus.UNAUTHORIZED)
+            new IsUnauthorizedResponse()
         );
     }
 }

--- a/src/test/java/com/artipie/docker/http/UploadEntityPutTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityPutTest.java
@@ -165,7 +165,7 @@ class UploadEntityPutTest {
                 Collections.emptyList(),
                 Flowable.empty()
             ),
-            new RsHasStatus(RsStatus.UNAUTHORIZED)
+            new IsUnauthorizedResponse()
         );
     }
 


### PR DESCRIPTION
Closes #117 
Unauthroized error responses contain body in proper JSON format.