### PR TITLE
#298 - Translating InvalidRepoNameException to error responses

### DIFF
--- a/src/main/java/com/artipie/docker/http/DockerSlice.java
+++ b/src/main/java/com/artipie/docker/http/DockerSlice.java
@@ -85,76 +85,78 @@ public final class DockerSlice extends Slice.Wrap {
     @SuppressWarnings("PMD.UnusedFormalParameter")
     public DockerSlice(final Docker docker, final Permissions perms, final Identities ids) {
         super(
-            new SliceRoute(
-                new RtRulePath(
-                    new RtRule.All(
-                        new RtRule.ByPath(BaseEntity.PATH),
-                        new RtRule.ByMethod(RqMethod.GET)
+            new ErrorHandlingSlice(
+                new SliceRoute(
+                    new RtRulePath(
+                        new RtRule.All(
+                            new RtRule.ByPath(BaseEntity.PATH),
+                            new RtRule.ByMethod(RqMethod.GET)
+                        ),
+                        authRead(new BaseEntity(), perms, ids)
                     ),
-                    authRead(new BaseEntity(), perms, ids)
-                ),
-                new RtRulePath(
-                    new RtRule.All(
-                        new RtRule.ByPath(ManifestEntity.PATH),
-                        new RtRule.ByMethod(RqMethod.HEAD)
+                    new RtRulePath(
+                        new RtRule.All(
+                            new RtRule.ByPath(ManifestEntity.PATH),
+                            new RtRule.ByMethod(RqMethod.HEAD)
+                        ),
+                        authRead(new ManifestEntity.Head(docker), perms, ids)
                     ),
-                    authRead(new ManifestEntity.Head(docker), perms, ids)
-                ),
-                new RtRulePath(
-                    new RtRule.All(
-                        new RtRule.ByPath(ManifestEntity.PATH),
-                        new RtRule.ByMethod(RqMethod.GET)
+                    new RtRulePath(
+                        new RtRule.All(
+                            new RtRule.ByPath(ManifestEntity.PATH),
+                            new RtRule.ByMethod(RqMethod.GET)
+                        ),
+                        authRead(new ManifestEntity.Get(docker), perms, ids)
                     ),
-                    authRead(new ManifestEntity.Get(docker), perms, ids)
-                ),
-                new RtRulePath(
-                    new RtRule.All(
-                        new RtRule.ByPath(ManifestEntity.PATH),
-                        new RtRule.ByMethod(RqMethod.PUT)
+                    new RtRulePath(
+                        new RtRule.All(
+                            new RtRule.ByPath(ManifestEntity.PATH),
+                            new RtRule.ByMethod(RqMethod.PUT)
+                        ),
+                        authWrite(new ManifestEntity.Put(docker), perms, ids)
                     ),
-                    authWrite(new ManifestEntity.Put(docker), perms, ids)
-                ),
-                new RtRulePath(
-                    new RtRule.All(
-                        new RtRule.ByPath(BlobEntity.PATH),
-                        new RtRule.ByMethod(RqMethod.HEAD)
+                    new RtRulePath(
+                        new RtRule.All(
+                            new RtRule.ByPath(BlobEntity.PATH),
+                            new RtRule.ByMethod(RqMethod.HEAD)
+                        ),
+                        authRead(new BlobEntity.Head(docker), perms, ids)
                     ),
-                    authRead(new BlobEntity.Head(docker), perms, ids)
-                ),
-                new RtRulePath(
-                    new RtRule.All(
-                        new RtRule.ByPath(BlobEntity.PATH),
-                        new RtRule.ByMethod(RqMethod.GET)
+                    new RtRulePath(
+                        new RtRule.All(
+                            new RtRule.ByPath(BlobEntity.PATH),
+                            new RtRule.ByMethod(RqMethod.GET)
+                        ),
+                        authRead(new BlobEntity.Get(docker), perms, ids)
                     ),
-                    authRead(new BlobEntity.Get(docker), perms, ids)
-                ),
-                new RtRulePath(
-                    new RtRule.All(
-                        new RtRule.ByPath(UploadEntity.PATH),
-                        new RtRule.ByMethod(RqMethod.POST)
+                    new RtRulePath(
+                        new RtRule.All(
+                            new RtRule.ByPath(UploadEntity.PATH),
+                            new RtRule.ByMethod(RqMethod.POST)
+                        ),
+                        authWrite(new UploadEntity.Post(docker), perms, ids)
                     ),
-                    authWrite(new UploadEntity.Post(docker), perms, ids)
-                ),
-                new RtRulePath(
-                    new RtRule.All(
-                        new RtRule.ByPath(UploadEntity.PATH),
-                        new RtRule.ByMethod(RqMethod.PATCH)
+                    new RtRulePath(
+                        new RtRule.All(
+                            new RtRule.ByPath(UploadEntity.PATH),
+                            new RtRule.ByMethod(RqMethod.PATCH)
+                        ),
+                        authWrite(new UploadEntity.Patch(docker), perms, ids)
                     ),
-                    authWrite(new UploadEntity.Patch(docker), perms, ids)
-                ),
-                new RtRulePath(
-                    new RtRule.All(
-                        new RtRule.ByPath(UploadEntity.PATH),
-                        new RtRule.ByMethod(RqMethod.PUT)
+                    new RtRulePath(
+                        new RtRule.All(
+                            new RtRule.ByPath(UploadEntity.PATH),
+                            new RtRule.ByMethod(RqMethod.PUT)
+                        ),
+                        authWrite(new UploadEntity.Put(docker), perms, ids)
                     ),
-                    authWrite(new UploadEntity.Put(docker), perms, ids)
-                ),
-                new RtRulePath(
-                    new RtRule.All(
-                        new RtRule.ByPath(UploadEntity.PATH),
-                        new RtRule.ByMethod(RqMethod.GET)
-                    ),
-                    authRead(new UploadEntity.Get(docker), perms, ids)
+                    new RtRulePath(
+                        new RtRule.All(
+                            new RtRule.ByPath(UploadEntity.PATH),
+                            new RtRule.ByMethod(RqMethod.GET)
+                        ),
+                        authRead(new UploadEntity.Get(docker), perms, ids)
+                    )
                 )
             )
         );

--- a/src/main/java/com/artipie/docker/http/ErrorHandlingSlice.java
+++ b/src/main/java/com/artipie/docker/http/ErrorHandlingSlice.java
@@ -1,0 +1,97 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.http;
+
+import com.artipie.docker.error.InvalidRepoNameException;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.rs.RsStatus;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import org.reactivestreams.Publisher;
+
+/**
+ * Slice that handles exceptions in origin slice by sending well-formed error responses.
+ *
+ * @since 0.5
+ */
+final class ErrorHandlingSlice implements Slice {
+
+    /**
+     * Origin.
+     */
+    private final Slice origin;
+
+    /**
+     * Ctor.
+     *
+     * @param origin Origin.
+     */
+    ErrorHandlingSlice(final Slice origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public Response response(
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body
+    ) {
+        final Response response = this.origin.response(line, headers, body);
+        return connection -> response.send(connection).handle(
+            (nothing, throwable) -> {
+                final CompletionStage<Void> result;
+                if (throwable == null) {
+                    result = CompletableFuture.completedFuture(nothing);
+                } else {
+                    result = handle(throwable)
+                        .map(rsp -> rsp.send(connection))
+                        .orElseGet(() -> CompletableFuture.failedFuture(throwable));
+                }
+                return result;
+            }
+        ).thenCompose(Function.identity());
+    }
+
+    /**
+     * Translates throwable to error response.
+     *
+     * @param throwable Throwable to translate.
+     * @return Result response, empty that throwable cannot be handled.
+     * @checkstyle ReturnCountCheck (3 lines)
+     */
+    @SuppressWarnings("PMD.OnlyOneReturn")
+    private static Optional<Response> handle(final Throwable throwable) {
+        if (throwable instanceof InvalidRepoNameException) {
+            return Optional.of(
+                new ErrorsResponse(RsStatus.BAD_REQUEST, (InvalidRepoNameException) throwable)
+            );
+        }
+        return Optional.empty();
+    }
+}

--- a/src/test/java/com/artipie/docker/http/ErrorHandlingSliceTest.java
+++ b/src/test/java/com/artipie/docker/http/ErrorHandlingSliceTest.java
@@ -23,23 +23,85 @@
  */
 package com.artipie.docker.http;
 
+import com.artipie.asto.ext.PublisherAs;
 import com.artipie.docker.error.InvalidRepoNameException;
+import com.artipie.docker.proxy.AuthClientSlice;
 import com.artipie.http.Headers;
+import com.artipie.http.Response;
+import com.artipie.http.client.jetty.JettyClientSlices;
+import com.artipie.http.headers.Header;
+import com.artipie.http.hm.ResponseMatcher;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rs.RsFull;
 import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.StandardRs;
 import io.reactivex.Flowable;
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link ErrorHandlingSlice}.
  *
  * @since 0.5
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class ErrorHandlingSliceTest {
+
+    @Test
+    void shouldPassRequestUnmodified() {
+        final String line = new RequestLine(RqMethod.GET, "/file.txt").toString();
+        final Header header = new Header("x-name", "some value");
+        final byte[] body = "text".getBytes();
+        new ErrorHandlingSlice(
+            (rqline, rqheaders, rqbody) -> {
+                MatcherAssert.assertThat(
+                    "Request line unmodified",
+                    rqline,
+                    new IsEqual<>(line)
+                );
+                MatcherAssert.assertThat(
+                    "Headers unmodified",
+                    rqheaders,
+                    Matchers.containsInAnyOrder(header)
+                );
+                MatcherAssert.assertThat(
+                    "Body unmodified",
+                    new PublisherAs(rqbody).bytes().toCompletableFuture().join(),
+                    new IsEqual<>(body)
+                );
+                return StandardRs.OK;
+            }
+        ).response(
+            line, new Headers.From(header), Flowable.just(ByteBuffer.wrap(body))
+        ).send(
+            (status, rsheaders, rsbody) -> CompletableFuture.allOf()
+        ).toCompletableFuture().join();
+    }
+
+    @Test
+    void shouldPassResponseUnmodified() {
+        final Header header = new Header("x-name", "some value");
+        final byte[] body = "text".getBytes();
+        final RsStatus status = RsStatus.OK;
+        final Response response = new AuthClientSlice(
+            new JettyClientSlices(),
+            (rsline, rsheaders, rsbody) -> new RsFull(
+                status,
+                new Headers.From(header),
+                Flowable.just(ByteBuffer.wrap(body))
+            )
+        ).response(new RequestLine(RqMethod.GET, "/").toString(), Headers.EMPTY, Flowable.empty());
+        MatcherAssert.assertThat(
+            response,
+            new ResponseMatcher(status, body, header)
+        );
+    }
 
     @Test
     void shouldHandleError() {


### PR DESCRIPTION
Part of #298 
`InvalidRepoNameException` thrown in slices translated to error response using `ErrorHandlingSlice`