### PR TITLE
#299 - Proper error body for forbidden response

### DIFF
--- a/src/main/java/com/artipie/docker/error/DeniedError.java
+++ b/src/main/java/com/artipie/docker/error/DeniedError.java
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.error;
+
+import java.util.Optional;
+
+/**
+ * The access controller denied access for the operation on a resource.
+ *
+ * @since 0.5
+ */
+public final class DeniedError implements DockerError {
+
+    @Override
+    public String code() {
+        return "DENIED";
+    }
+
+    @Override
+    public String message() {
+        return "requested access to the resource is denied";
+    }
+
+    @Override
+    public Optional<String> detail() {
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/artipie/docker/http/DockerAuthSlice.java
+++ b/src/main/java/com/artipie/docker/http/DockerAuthSlice.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.docker.http;
 
+import com.artipie.docker.error.DeniedError;
 import com.artipie.docker.error.UnauthorizedError;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
@@ -67,6 +68,11 @@ final class DockerAuthSlice implements Slice {
                 if (rsstatus == RsStatus.UNAUTHORIZED) {
                     sent = new RsWithHeaders(
                         new ErrorsResponse(rsstatus, new UnauthorizedError()),
+                        rsheaders
+                    ).send(connection);
+                } else if (rsstatus == RsStatus.FORBIDDEN) {
+                    sent = new RsWithHeaders(
+                        new ErrorsResponse(rsstatus, new DeniedError()),
                         rsheaders
                     ).send(connection);
                 } else {


### PR DESCRIPTION
For #299 
Adding proper error body for forbidden response in `DockerAuthSlice`.