### PR TITLE
#299 - Two users in TestAuthentication, HTTP upgraded to 0.15.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.15.5</version>
+      <version>0.15.7</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/main/java/com/artipie/docker/http/DockerSlice.java
+++ b/src/main/java/com/artipie/docker/http/DockerSlice.java
@@ -32,6 +32,7 @@ import com.artipie.http.auth.Permission;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.auth.SliceAuth;
 import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rt.ByMethodsRule;
 import com.artipie.http.rt.RtRule;
 import com.artipie.http.rt.RtRulePath;
 import com.artipie.http.rt.SliceRoute;
@@ -90,70 +91,70 @@ public final class DockerSlice extends Slice.Wrap {
                     new RtRulePath(
                         new RtRule.All(
                             new RtRule.ByPath(BaseEntity.PATH),
-                            new RtRule.ByMethod(RqMethod.GET)
+                            ByMethodsRule.Standard.GET
                         ),
                         authRead(new BaseEntity(), perms, ids)
                     ),
                     new RtRulePath(
                         new RtRule.All(
                             new RtRule.ByPath(ManifestEntity.PATH),
-                            new RtRule.ByMethod(RqMethod.HEAD)
+                            new ByMethodsRule(RqMethod.HEAD)
                         ),
                         authRead(new ManifestEntity.Head(docker), perms, ids)
                     ),
                     new RtRulePath(
                         new RtRule.All(
                             new RtRule.ByPath(ManifestEntity.PATH),
-                            new RtRule.ByMethod(RqMethod.GET)
+                            ByMethodsRule.Standard.GET
                         ),
                         authRead(new ManifestEntity.Get(docker), perms, ids)
                     ),
                     new RtRulePath(
                         new RtRule.All(
                             new RtRule.ByPath(ManifestEntity.PATH),
-                            new RtRule.ByMethod(RqMethod.PUT)
+                            ByMethodsRule.Standard.PUT
                         ),
                         authWrite(new ManifestEntity.Put(docker), perms, ids)
                     ),
                     new RtRulePath(
                         new RtRule.All(
                             new RtRule.ByPath(BlobEntity.PATH),
-                            new RtRule.ByMethod(RqMethod.HEAD)
+                            new ByMethodsRule(RqMethod.HEAD)
                         ),
                         authRead(new BlobEntity.Head(docker), perms, ids)
                     ),
                     new RtRulePath(
                         new RtRule.All(
                             new RtRule.ByPath(BlobEntity.PATH),
-                            new RtRule.ByMethod(RqMethod.GET)
+                            ByMethodsRule.Standard.GET
                         ),
                         authRead(new BlobEntity.Get(docker), perms, ids)
                     ),
                     new RtRulePath(
                         new RtRule.All(
                             new RtRule.ByPath(UploadEntity.PATH),
-                            new RtRule.ByMethod(RqMethod.POST)
+                            ByMethodsRule.Standard.POST
                         ),
                         authWrite(new UploadEntity.Post(docker), perms, ids)
                     ),
                     new RtRulePath(
                         new RtRule.All(
                             new RtRule.ByPath(UploadEntity.PATH),
-                            new RtRule.ByMethod(RqMethod.PATCH)
+                            new ByMethodsRule(RqMethod.PATCH)
                         ),
                         authWrite(new UploadEntity.Patch(docker), perms, ids)
                     ),
                     new RtRulePath(
                         new RtRule.All(
                             new RtRule.ByPath(UploadEntity.PATH),
-                            new RtRule.ByMethod(RqMethod.PUT)
+                            ByMethodsRule.Standard.PUT
                         ),
                         authWrite(new UploadEntity.Put(docker), perms, ids)
                     ),
                     new RtRulePath(
                         new RtRule.All(
                             new RtRule.ByPath(UploadEntity.PATH),
-                            new RtRule.ByMethod(RqMethod.GET)
+                            ByMethodsRule.Standard.GET
                         ),
                         authRead(new UploadEntity.Get(docker), perms, ids)
                     )

--- a/src/test/java/com/artipie/docker/http/BaseEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/BaseEntityGetTest.java
@@ -52,11 +52,17 @@ class BaseEntityGetTest {
      */
     private DockerSlice slice;
 
+    /**
+     * User with right permissions.
+     */
+    private TestAuthentication.User user;
+
     @BeforeEach
     void setUp() {
+        this.user = TestAuthentication.ALICE;
         this.slice = new DockerSlice(
             new AstoDocker(new InMemoryStorage()),
-            new Permissions.Single(TestAuthentication.USERNAME, DockerSlice.READ),
+            new Permissions.Single(this.user.name(), DockerSlice.READ),
             new TestAuthentication()
         );
     }
@@ -65,7 +71,7 @@ class BaseEntityGetTest {
     void shouldRespondOkToVersionCheck() {
         final Response response = this.slice.response(
             new RequestLine(RqMethod.GET, "/v2/").toString(),
-            new TestAuthentication.Headers(),
+            this.user.headers(),
             Flowable.empty()
         );
         MatcherAssert.assertThat(

--- a/src/test/java/com/artipie/docker/http/BlobEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/BlobEntityGetTest.java
@@ -55,11 +55,17 @@ class BlobEntityGetTest {
      */
     private DockerSlice slice;
 
+    /**
+     * User with right permissions.
+     */
+    private TestAuthentication.User user;
+
     @BeforeEach
     void setUp() {
+        this.user = TestAuthentication.ALICE;
         this.slice = new DockerSlice(
             new AstoDocker(new ExampleStorage()),
-            new Permissions.Single(TestAuthentication.USERNAME, DockerSlice.READ),
+            new Permissions.Single(this.user.name(), DockerSlice.READ),
             new TestAuthentication()
         );
     }
@@ -76,7 +82,7 @@ class BlobEntityGetTest {
                 RqMethod.GET,
                 String.format("/v2/test/blobs/%s", digest)
             ).toString(),
-            new TestAuthentication.Headers(),
+            this.user.headers(),
             Flowable.empty()
         );
         final Key expected = new Key.From(
@@ -106,7 +112,7 @@ class BlobEntityGetTest {
                         "sha256:0123456789012345678901234567890123456789012345678901234567890123"
                     )
                 ).toString(),
-                new TestAuthentication.Headers(),
+                this.user.headers(),
                 Flowable.empty()
             ),
             new IsErrorsResponse(RsStatus.NOT_FOUND, "BLOB_UNKNOWN")

--- a/src/test/java/com/artipie/docker/http/BlobEntityHeadTest.java
+++ b/src/test/java/com/artipie/docker/http/BlobEntityHeadTest.java
@@ -53,11 +53,17 @@ class BlobEntityHeadTest {
      */
     private DockerSlice slice;
 
+    /**
+     * User with right permissions.
+     */
+    private TestAuthentication.User user;
+
     @BeforeEach
     void setUp() {
+        this.user = TestAuthentication.ALICE;
         this.slice = new DockerSlice(
             new AstoDocker(new ExampleStorage()),
-            new Permissions.Single(TestAuthentication.USERNAME, DockerSlice.READ),
+            new Permissions.Single(this.user.name(), DockerSlice.READ),
             new TestAuthentication()
         );
     }
@@ -74,7 +80,7 @@ class BlobEntityHeadTest {
                 RqMethod.HEAD,
                 String.format("/v2/test/blobs/%s", digest)
             ).toString(),
-            new TestAuthentication.Headers(),
+            this.user.headers(),
             Flowable.empty()
         );
         MatcherAssert.assertThat(
@@ -99,7 +105,7 @@ class BlobEntityHeadTest {
                         "sha256:0123456789012345678901234567890123456789012345678901234567890123"
                     )
                 ).toString(),
-                new TestAuthentication.Headers(),
+                this.user.headers(),
                 Flowable.empty()
             ),
             new IsErrorsResponse(RsStatus.NOT_FOUND, "BLOB_UNKNOWN")

--- a/src/test/java/com/artipie/docker/http/DockerAuthITCase.java
+++ b/src/test/java/com/artipie/docker/http/DockerAuthITCase.java
@@ -56,18 +56,19 @@ final class DockerAuthITCase {
 
     @BeforeEach
     void setUp() throws Exception {
+        final TestAuthentication.User user = TestAuthentication.ALICE;
         this.repo = new DockerRepository(
             new DockerSlice(
                 new AstoDocker(new InMemoryStorage()),
-                (name, action) -> TestAuthentication.USERNAME.equals(name),
+                (name, action) -> user.name().equals(name),
                 new TestAuthentication()
             )
         );
         this.repo.start();
         this.cli.run(
             "login",
-            "--username", TestAuthentication.USERNAME,
-            "--password", TestAuthentication.PASSWORD,
+            "--username", user.name(),
+            "--password", user.password(),
             this.repo.url()
         );
     }

--- a/src/test/java/com/artipie/docker/http/ManifestEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityGetTest.java
@@ -60,11 +60,17 @@ class ManifestEntityGetTest {
      */
     private DockerSlice slice;
 
+    /**
+     * User with right permissions.
+     */
+    private TestAuthentication.User user;
+
     @BeforeEach
     void setUp() {
+        this.user = TestAuthentication.ALICE;
         this.slice = new DockerSlice(
             new AstoDocker(new ExampleStorage()),
-            new Permissions.Single(TestAuthentication.USERNAME, DockerSlice.READ),
+            new Permissions.Single(this.user.name(), DockerSlice.READ),
             new TestAuthentication()
         );
     }
@@ -164,12 +170,12 @@ class ManifestEntityGetTest {
      *
      * @since 0.4
      */
-    private static class Headers extends com.artipie.http.Headers.Wrap {
+    private class Headers extends com.artipie.http.Headers.Wrap {
 
         Headers() {
             super(
                 new Headers.From(
-                    new TestAuthentication.Headers(),
+                    ManifestEntityGetTest.this.user.headers(),
                     new Header("Accept", "application/vnd.docker.distribution.manifest.v2+json")
                 )
             );

--- a/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
@@ -57,11 +57,17 @@ class ManifestEntityHeadTest {
      */
     private DockerSlice slice;
 
+    /**
+     * User with right permissions.
+     */
+    private TestAuthentication.User user;
+
     @BeforeEach
     void setUp() {
+        this.user = TestAuthentication.ALICE;
         this.slice = new DockerSlice(
             new AstoDocker(new ExampleStorage()),
-            new Permissions.Single(TestAuthentication.USERNAME, DockerSlice.READ),
+            new Permissions.Single(this.user.name(), DockerSlice.READ),
             new TestAuthentication()
         );
     }
@@ -146,12 +152,12 @@ class ManifestEntityHeadTest {
      *
      * @since 0.4
      */
-    private static class Headers extends com.artipie.http.Headers.Wrap {
+    private class Headers extends com.artipie.http.Headers.Wrap {
 
         Headers() {
             super(
                 new Headers.From(
-                    new TestAuthentication.Headers(),
+                    ManifestEntityHeadTest.this.user.headers(),
                     new Header("Accept", "application/vnd.docker.distribution.manifest.v2+json")
                 )
             );

--- a/src/test/java/com/artipie/docker/http/ManifestEntityPutTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityPutTest.java
@@ -63,12 +63,18 @@ class ManifestEntityPutTest {
      */
     private Docker docker;
 
+    /**
+     * User with right permissions.
+     */
+    private TestAuthentication.User user;
+
     @BeforeEach
     void setUp() {
         this.docker = new AstoDocker(new InMemoryStorage());
+        this.user = TestAuthentication.ALICE;
         this.slice = new DockerSlice(
             this.docker,
-            new Permissions.Single(TestAuthentication.USERNAME, DockerSlice.WRITE),
+            new Permissions.Single(this.user.name(), DockerSlice.WRITE),
             new TestAuthentication()
         );
     }
@@ -79,7 +85,7 @@ class ManifestEntityPutTest {
         MatcherAssert.assertThat(
             this.slice.response(
                 new RequestLine(RqMethod.PUT, String.format("%s", path)).toString(),
-                new TestAuthentication.Headers(),
+                this.user.headers(),
                 this.manifest()
             ),
             new ResponseMatcher(
@@ -105,7 +111,7 @@ class ManifestEntityPutTest {
         MatcherAssert.assertThat(
             this.slice.response(
                 new RequestLine(RqMethod.PUT, String.format("%s", path)).toString(),
-                new TestAuthentication.Headers(),
+                this.user.headers(),
                 this.manifest()
             ),
             new ResponseMatcher(

--- a/src/test/java/com/artipie/docker/http/UploadEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityGetTest.java
@@ -61,12 +61,18 @@ public final class UploadEntityGetTest {
      */
     private DockerSlice slice;
 
+    /**
+     * User with right permissions.
+     */
+    private TestAuthentication.User user;
+
     @BeforeEach
     void setUp() {
         this.docker = new AstoDocker(new InMemoryStorage());
+        this.user = TestAuthentication.ALICE;
         this.slice = new DockerSlice(
             this.docker,
-            new Permissions.Single(TestAuthentication.USERNAME, DockerSlice.READ),
+            new Permissions.Single(this.user.name(), DockerSlice.READ),
             new TestAuthentication()
         );
     }
@@ -81,7 +87,7 @@ public final class UploadEntityGetTest {
         final String path = String.format("/v2/%s/blobs/uploads/%s", name, upload.uuid());
         final Response response = this.slice.response(
             new RequestLine(RqMethod.GET, String.format("%s", path)).toString(),
-            new TestAuthentication.Headers(),
+            this.user.headers(),
             Flowable.empty()
         );
         MatcherAssert.assertThat(
@@ -106,7 +112,7 @@ public final class UploadEntityGetTest {
         final String path = String.format("/v2/%s/blobs/uploads/%s", name, upload.uuid());
         final Response response = this.slice.response(
             new RequestLine(RqMethod.GET, String.format("%s", path)).toString(),
-            new TestAuthentication.Headers(),
+            this.user.headers(),
             Flowable.empty()
         );
         MatcherAssert.assertThat(
@@ -132,7 +138,7 @@ public final class UploadEntityGetTest {
         final String path = String.format("/v2/%s/blobs/uploads/%s", name, upload.uuid());
         final Response get = this.slice.response(
             new RequestLine(RqMethod.GET, String.format("%s", path)).toString(),
-            new TestAuthentication.Headers(),
+            this.user.headers(),
             Flowable.empty()
         );
         MatcherAssert.assertThat(
@@ -150,7 +156,7 @@ public final class UploadEntityGetTest {
     void shouldReturnNotFoundWhenUploadNotExists() {
         final Response response = this.slice.response(
             new RequestLine(RqMethod.GET, "/v2/test/blobs/uploads/12345").toString(),
-            new TestAuthentication.Headers(),
+            this.user.headers(),
             Flowable.empty()
         );
         MatcherAssert.assertThat(

--- a/src/test/java/com/artipie/docker/http/UploadEntityPatchTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityPatchTest.java
@@ -62,12 +62,18 @@ class UploadEntityPatchTest {
      */
     private DockerSlice slice;
 
+    /**
+     * User with right permissions.
+     */
+    private TestAuthentication.User user;
+
     @BeforeEach
     void setUp() {
         this.docker = new AstoDocker(new InMemoryStorage());
+        this.user = TestAuthentication.ALICE;
         this.slice = new DockerSlice(
             this.docker,
-            new Permissions.Single(TestAuthentication.USERNAME, DockerSlice.WRITE),
+            new Permissions.Single(this.user.name(), DockerSlice.WRITE),
             new TestAuthentication()
         );
     }
@@ -83,7 +89,7 @@ class UploadEntityPatchTest {
         final byte[] data = "data".getBytes();
         final Response response = this.slice.response(
             new RequestLine(RqMethod.PATCH, String.format("%s", path)).toString(),
-            new TestAuthentication.Headers(),
+            this.user.headers(),
             Flowable.just(ByteBuffer.wrap(data))
         );
         MatcherAssert.assertThat(
@@ -102,7 +108,7 @@ class UploadEntityPatchTest {
     void shouldReturnNotFoundWhenUploadNotExists() {
         final Response response = this.slice.response(
             new RequestLine(RqMethod.PATCH, "/v2/test/blobs/uploads/12345").toString(),
-            new TestAuthentication.Headers(),
+            this.user.headers(),
             Flowable.empty()
         );
         MatcherAssert.assertThat(

--- a/src/test/java/com/artipie/docker/http/UploadEntityPostTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityPostTest.java
@@ -56,11 +56,17 @@ class UploadEntityPostTest {
      */
     private DockerSlice slice;
 
+    /**
+     * User with right permissions.
+     */
+    private TestAuthentication.User user;
+
     @BeforeEach
     void setUp() {
+        this.user = TestAuthentication.ALICE;
         this.slice = new DockerSlice(
             new AstoDocker(new InMemoryStorage()),
-            new Permissions.Single(TestAuthentication.USERNAME, DockerSlice.WRITE),
+            new Permissions.Single(this.user.name(), DockerSlice.WRITE),
             new TestAuthentication()
         );
     }
@@ -69,7 +75,7 @@ class UploadEntityPostTest {
     void shouldReturnInitialUploadStatus() {
         final Response response = this.slice.response(
             new RequestLine(RqMethod.POST, "/v2/test/blobs/uploads/").toString(),
-            new TestAuthentication.Headers(),
+            this.user.headers(),
             Flowable.empty()
         );
         MatcherAssert.assertThat(

--- a/src/test/java/com/artipie/docker/http/UploadEntityPutTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityPutTest.java
@@ -72,13 +72,19 @@ class UploadEntityPutTest {
      */
     private DockerSlice slice;
 
+    /**
+     * User with right permissions.
+     */
+    private TestAuthentication.User user;
+
     @BeforeEach
     void setUp() {
         this.storage = new InMemoryStorage();
         this.docker = new AstoDocker(this.storage);
+        this.user = TestAuthentication.ALICE;
         this.slice = new DockerSlice(
             this.docker,
-            new Permissions.Single(TestAuthentication.USERNAME, DockerSlice.WRITE),
+            new Permissions.Single(this.user.name(), DockerSlice.WRITE),
             new TestAuthentication()
         );
     }
@@ -98,7 +104,7 @@ class UploadEntityPutTest {
         );
         final Response response = this.slice.response(
             UploadEntityPutTest.requestLine(name, upload.uuid(), digest),
-            new TestAuthentication.Headers(),
+            this.user.headers(),
             Flowable.empty()
         );
         MatcherAssert.assertThat(
@@ -130,7 +136,7 @@ class UploadEntityPutTest {
             "Returns 400 status",
             this.slice.response(
                 UploadEntityPutTest.requestLine(name, upload.uuid(), "sha256:0000"),
-                new TestAuthentication.Headers(),
+                this.user.headers(),
                 Flowable.empty()
             ),
             new RsHasStatus(RsStatus.BAD_REQUEST)
@@ -148,7 +154,7 @@ class UploadEntityPutTest {
     void shouldReturnNotFoundWhenUploadNotExists() {
         final Response response = this.slice.response(
             new RequestLine(RqMethod.PUT, "/v2/test/blobs/uploads/12345").toString(),
-            new TestAuthentication.Headers(),
+            this.user.headers(),
             Flowable.empty()
         );
         MatcherAssert.assertThat(


### PR DESCRIPTION
Part of #299 
Changed `TestAuthentication`. One user will have permissions in tests and another one will not.
HTTP upgraded to 0.15.7 to use new `Authentication.Joined` class