### PR TITLE
Update http to 0.16.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ SOFTWARE.
   <parent>
     <groupId>com.artipie</groupId>
     <artifactId>ppom</artifactId>
-    <version>0.3.9</version>
+    <version>0.4.1</version>
   </parent>
   <name>docker-adapter</name>
   <url>https://github.com/artipie/docker-adapter</url>
@@ -62,7 +62,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.26</version>
+      <version>0.28</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.16.1</version>
+      <version>0.16.2</version>
     </dependency>
     <dependency>
       <groupId>com.artipie</groupId>

--- a/src/test/java/com/artipie/docker/http/DockerAuthITCase.java
+++ b/src/test/java/com/artipie/docker/http/DockerAuthITCase.java
@@ -60,7 +60,7 @@ final class DockerAuthITCase {
         this.repo = new DockerRepository(
             new DockerSlice(
                 new AstoDocker(new InMemoryStorage()),
-                (name, action) -> user.name().equals(name),
+                (identity, action) -> user.name().equals(identity.name()),
                 new TestAuthentication()
             )
         );


### PR DESCRIPTION
Updated http version to `0.16.2`, also bumped ppom and asto.