### PR TITLE
#341 - Using FailedCompletionStage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.28</version>
+      <version>0.31</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>

--- a/src/main/java/com/artipie/docker/http/ErrorHandlingSlice.java
+++ b/src/main/java/com/artipie/docker/http/ErrorHandlingSlice.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.docker.http;
 
+import com.artipie.asto.FailedCompletionStage;
 import com.artipie.docker.error.InvalidManifestException;
 import com.artipie.docker.error.InvalidRepoNameException;
 import com.artipie.docker.error.InvalidTagNameException;
@@ -84,7 +85,7 @@ final class ErrorHandlingSlice implements Slice {
                         } else {
                             result = handle(throwable)
                                 .map(rsp -> rsp.send(connection))
-                                .orElseGet(() -> CompletableFuture.failedFuture(throwable));
+                                .orElseGet(() -> new FailedCompletionStage<>(throwable));
                         }
                         return result;
                     }

--- a/src/main/java/com/artipie/docker/proxy/ProxyLayers.java
+++ b/src/main/java/com/artipie/docker/proxy/ProxyLayers.java
@@ -24,6 +24,7 @@
 package com.artipie.docker.proxy;
 
 import com.artipie.asto.Content;
+import com.artipie.asto.FailedCompletionStage;
 import com.artipie.docker.Blob;
 import com.artipie.docker.Digest;
 import com.artipie.docker.Layers;
@@ -96,7 +97,7 @@ public final class ProxyLayers implements Layers {
                 } else if (status == RsStatus.NOT_FOUND) {
                     result = CompletableFuture.completedFuture(Optional.empty());
                 } else {
-                    result = CompletableFuture.failedFuture(
+                    result = new FailedCompletionStage<>(
                         new IllegalArgumentException(String.format("Unexpected status: %s", status))
                     );
                 }

--- a/src/main/java/com/artipie/docker/proxy/ProxyManifests.java
+++ b/src/main/java/com/artipie/docker/proxy/ProxyManifests.java
@@ -24,6 +24,7 @@
 package com.artipie.docker.proxy;
 
 import com.artipie.asto.Content;
+import com.artipie.asto.FailedCompletionStage;
 import com.artipie.asto.ext.PublisherAs;
 import com.artipie.docker.Digest;
 import com.artipie.docker.Manifests;
@@ -94,7 +95,7 @@ public final class ProxyManifests implements Manifests {
                 } else if (status == RsStatus.NOT_FOUND) {
                     result = CompletableFuture.completedFuture(Optional.empty());
                 } else {
-                    result = CompletableFuture.failedFuture(
+                    result = new FailedCompletionStage<>(
                         new IllegalArgumentException(String.format("Unexpected status: %s", status))
                     );
                 }

--- a/src/test/java/com/artipie/docker/fake/FaultyGetLayers.java
+++ b/src/test/java/com/artipie/docker/fake/FaultyGetLayers.java
@@ -24,11 +24,11 @@
 package com.artipie.docker.fake;
 
 import com.artipie.asto.Content;
+import com.artipie.asto.FailedCompletionStage;
 import com.artipie.docker.Blob;
 import com.artipie.docker.Digest;
 import com.artipie.docker.Layers;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -45,6 +45,6 @@ public final class FaultyGetLayers implements Layers {
 
     @Override
     public CompletionStage<Optional<Blob>> get(final Digest digest) {
-        return CompletableFuture.failedFuture(new IllegalStateException());
+        return new FailedCompletionStage<>(new IllegalStateException());
     }
 }

--- a/src/test/java/com/artipie/docker/fake/FaultyGetManifests.java
+++ b/src/test/java/com/artipie/docker/fake/FaultyGetManifests.java
@@ -24,11 +24,11 @@
 package com.artipie.docker.fake;
 
 import com.artipie.asto.Content;
+import com.artipie.asto.FailedCompletionStage;
 import com.artipie.docker.Manifests;
 import com.artipie.docker.manifest.Manifest;
 import com.artipie.docker.ref.ManifestRef;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -45,6 +45,6 @@ public final class FaultyGetManifests implements Manifests {
 
     @Override
     public CompletionStage<Optional<Manifest>> get(final ManifestRef ref) {
-        return CompletableFuture.failedFuture(new IllegalStateException());
+        return new FailedCompletionStage<>(new IllegalStateException());
     }
 }

--- a/src/test/java/com/artipie/docker/http/ErrorHandlingSliceTest.java
+++ b/src/test/java/com/artipie/docker/http/ErrorHandlingSliceTest.java
@@ -24,6 +24,7 @@
 package com.artipie.docker.http;
 
 import com.artipie.asto.Content;
+import com.artipie.asto.FailedCompletionStage;
 import com.artipie.asto.ext.PublisherAs;
 import com.artipie.docker.error.InvalidManifestException;
 import com.artipie.docker.error.InvalidRepoNameException;
@@ -116,9 +117,7 @@ class ErrorHandlingSliceTest {
     void shouldHandleErrorInvalid(final RuntimeException exception, final String code) {
         MatcherAssert.assertThat(
             new ErrorHandlingSlice(
-                (line, headers, body) -> connection -> CompletableFuture.failedFuture(
-                    exception
-                )
+                (line, headers, body) -> connection -> new FailedCompletionStage<>(exception)
             ).response(
                 new RequestLine(RqMethod.GET, "/").toString(),
                 Headers.EMPTY,


### PR DESCRIPTION
Part of #341
Using `FailedCompletionStage` instead of `CompletableFuture.failedFuture`