### PR TITLE
#356 - InvalidManifestException in case of empty manifest

### DIFF
--- a/src/main/java/com/artipie/docker/error/InvalidManifestException.java
+++ b/src/main/java/com/artipie/docker/error/InvalidManifestException.java
@@ -43,6 +43,16 @@ public final class InvalidManifestException extends RuntimeException implements 
         super(details);
     }
 
+    /**
+     * Ctor.
+     *
+     * @param details Error details.
+     * @param cause Original cause.
+     */
+    public InvalidManifestException(final String details, final Throwable cause) {
+        super(details, cause);
+    }
+
     @Override
     public String code() {
         return "MANIFEST_INVALID";

--- a/src/main/java/com/artipie/docker/http/ErrorHandlingSlice.java
+++ b/src/main/java/com/artipie/docker/http/ErrorHandlingSlice.java
@@ -34,6 +34,7 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import org.reactivestreams.Publisher;
@@ -121,6 +122,9 @@ final class ErrorHandlingSlice implements Slice {
             return Optional.of(
                 new ErrorsResponse(RsStatus.BAD_REQUEST, (InvalidManifestException) throwable)
             );
+        }
+        if (throwable instanceof CompletionException) {
+            return Optional.ofNullable(throwable.getCause()).flatMap(ErrorHandlingSlice::handle);
         }
         return Optional.empty();
     }

--- a/src/test/java/com/artipie/docker/http/ErrorHandlingSliceTest.java
+++ b/src/test/java/com/artipie/docker/http/ErrorHandlingSliceTest.java
@@ -40,9 +40,13 @@ import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsFull;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.StandardRs;
+import com.google.common.collect.Streams;
 import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -218,10 +222,19 @@ class ErrorHandlingSliceTest {
         final InvalidRepoNameException repo = new InvalidRepoNameException("repo name exception");
         final InvalidTagNameException tag = new InvalidTagNameException("tag name exception");
         final InvalidManifestException mnf = new InvalidManifestException("manifest exception");
-        return Stream.of(
+        final List<Arguments> plain = Stream.of(
             Arguments.of(repo, repo.code()),
             Arguments.of(tag, tag.code()),
             Arguments.of(mnf, mnf.code())
+        ).collect(Collectors.toList());
+        return Streams.concat(
+            plain.stream(),
+            plain.stream().map(
+                original -> Arguments.of(
+                    new CompletionException((Throwable) original.get()[0]),
+                    original.get()[1]
+                )
+            )
         );
     }
 }


### PR DESCRIPTION
Closes #356 
`InvalidManifestException` in case of empty manifest