### PR TITLE
#385 - ExampleStorage makes a copy of reference storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.31</version>
+      <version>0.33.6</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>

--- a/src/test/java/com/artipie/docker/ExampleStorage.java
+++ b/src/test/java/com/artipie/docker/ExampleStorage.java
@@ -23,8 +23,10 @@
  */
 package com.artipie.docker;
 
+import com.artipie.asto.Copy;
 import com.artipie.asto.Storage;
 import com.artipie.asto.fs.FileStorage;
+import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
 
 /**
@@ -38,6 +40,19 @@ public final class ExampleStorage extends Storage.Wrap {
      * Ctor.
      */
     public ExampleStorage() {
-        super(new FileStorage(new TestResource("example-my-alpine").asPath()));
+        super(copy());
+    }
+
+    /**
+     * Copy example data to new in-memory storage.
+     *
+     * @return Copied storage.
+     */
+    private static Storage copy() {
+        final Storage target = new InMemoryStorage();
+        new Copy(new FileStorage(new TestResource("example-my-alpine").asPath()))
+            .copy(target)
+            .toCompletableFuture().join();
+        return target;
     }
 }


### PR DESCRIPTION
Closes #385 
`ExampleStorage` makes a copy of reference storage