### PR TITLE
#387 - Added Content-Type to error response

### DIFF
--- a/src/main/java/com/artipie/docker/http/CatalogEntity.java
+++ b/src/main/java/com/artipie/docker/http/CatalogEntity.java
@@ -28,7 +28,6 @@ import com.artipie.docker.RepoName;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
-import com.artipie.http.headers.ContentType;
 import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rq.RqParams;
 import com.artipie.http.rs.RsStatus;
@@ -95,7 +94,7 @@ final class CatalogEntity {
                     catalog -> new RsWithBody(
                         new RsWithHeaders(
                             new RsWithStatus(RsStatus.OK),
-                            new ContentType("application/json; charset=utf-8")
+                            new JsonContentType()
                         ),
                         catalog.json()
                     )

--- a/src/main/java/com/artipie/docker/http/ErrorsResponse.java
+++ b/src/main/java/com/artipie/docker/http/ErrorsResponse.java
@@ -27,6 +27,7 @@ import com.artipie.docker.error.DockerError;
 import com.artipie.http.Response;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithBody;
+import com.artipie.http.rs.RsWithHeaders;
 import com.artipie.http.rs.RsWithStatus;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -60,7 +61,11 @@ final class ErrorsResponse extends Response.Wrap {
      */
     protected ErrorsResponse(final RsStatus status, final Collection<DockerError> errors) {
         super(
-            new RsWithBody(new RsWithStatus(status), json(errors), StandardCharsets.UTF_8)
+            new RsWithBody(
+                new RsWithHeaders(new RsWithStatus(status), new JsonContentType()),
+                json(errors),
+                StandardCharsets.UTF_8
+            )
         );
     }
 

--- a/src/main/java/com/artipie/docker/http/ErrorsResponse.java
+++ b/src/main/java/com/artipie/docker/http/ErrorsResponse.java
@@ -29,6 +29,7 @@ import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithBody;
 import com.artipie.http.rs.RsWithHeaders;
 import com.artipie.http.rs.RsWithStatus;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,6 +43,11 @@ import javax.json.JsonObjectBuilder;
  * @since 0.5
  */
 final class ErrorsResponse extends Response.Wrap {
+
+    /**
+     * Charset used for JSON encoding.
+     */
+    private static final Charset CHARSET = StandardCharsets.UTF_8;
 
     /**
      * Ctor.
@@ -62,9 +68,12 @@ final class ErrorsResponse extends Response.Wrap {
     protected ErrorsResponse(final RsStatus status, final Collection<DockerError> errors) {
         super(
             new RsWithBody(
-                new RsWithHeaders(new RsWithStatus(status), new JsonContentType()),
+                new RsWithHeaders(
+                    new RsWithStatus(status),
+                    new JsonContentType(ErrorsResponse.CHARSET)
+                ),
                 json(errors),
-                StandardCharsets.UTF_8
+                ErrorsResponse.CHARSET
             )
         );
     }

--- a/src/main/java/com/artipie/docker/http/JsonContentType.java
+++ b/src/main/java/com/artipie/docker/http/JsonContentType.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.http;
+
+import com.artipie.http.headers.ContentType;
+import com.artipie.http.headers.Header;
+
+/**
+ * Content-Type header with "application/json; charset=utf-8" value.
+ *
+ * @since 0.9
+ */
+public class JsonContentType extends Header.Wrap {
+
+    /**
+     * Ctor.
+     */
+    protected JsonContentType() {
+        super(new ContentType("application/json; charset=utf-8"));
+    }
+}

--- a/src/main/java/com/artipie/docker/http/TagsEntity.java
+++ b/src/main/java/com/artipie/docker/http/TagsEntity.java
@@ -30,7 +30,6 @@ import com.artipie.docker.misc.RqByRegex;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
-import com.artipie.http.headers.ContentType;
 import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rq.RqParams;
 import com.artipie.http.rs.RsStatus;
@@ -100,7 +99,7 @@ final class TagsEntity {
                     tags -> new RsWithBody(
                         new RsWithHeaders(
                             new RsWithStatus(RsStatus.OK),
-                            new ContentType("application/json; charset=utf-8")
+                            new JsonContentType()
                         ),
                         tags.json()
                     )

--- a/src/test/java/com/artipie/docker/http/DockerAuthSliceTest.java
+++ b/src/test/java/com/artipie/docker/http/DockerAuthSliceTest.java
@@ -74,7 +74,9 @@ public final class DockerAuthSliceTest {
             new AllOf<>(
                 Arrays.asList(
                     new IsUnauthorizedResponse(),
-                    new RsHasHeaders(new Headers.From(headers, new ContentLength("72")))
+                    new RsHasHeaders(
+                        new Headers.From(headers, new JsonContentType(), new ContentLength("72"))
+                    )
                 )
             )
         );
@@ -100,7 +102,9 @@ public final class DockerAuthSliceTest {
             new AllOf<>(
                 Arrays.asList(
                     new IsDeniedResponse(),
-                    new RsHasHeaders(new Headers.From(headers, new ContentLength("85")))
+                    new RsHasHeaders(
+                        new Headers.From(headers, new JsonContentType(), new ContentLength("85"))
+                    )
                 )
             )
         );

--- a/src/test/java/com/artipie/docker/http/IsErrorsResponse.java
+++ b/src/test/java/com/artipie/docker/http/IsErrorsResponse.java
@@ -24,7 +24,9 @@
 package com.artipie.docker.http;
 
 import com.artipie.http.Response;
+import com.artipie.http.headers.Header;
 import com.artipie.http.hm.RsHasBody;
+import com.artipie.http.hm.RsHasHeaders;
 import com.artipie.http.hm.RsHasStatus;
 import com.artipie.http.rs.RsStatus;
 import java.io.ByteArrayInputStream;
@@ -36,6 +38,7 @@ import javax.json.JsonValue;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.AllOf;
 import org.hamcrest.core.IsNot;
@@ -48,6 +51,7 @@ import wtf.g4s8.hamcrest.json.JsonValueIs;
  * Matcher for errors response.
  *
  * @since 0.5
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class IsErrorsResponse extends BaseMatcher<Response> {
 
@@ -66,6 +70,11 @@ public final class IsErrorsResponse extends BaseMatcher<Response> {
         this.delegate = new AllOf<>(
             Arrays.asList(
                 new RsHasStatus(status),
+                new RsHasHeaders(
+                    Matchers.containsInRelativeOrder(
+                        new Header("Content-Type", "application/json; charset=utf-8")
+                    )
+                ),
                 new RsHasBody(
                     new IsJson(
                         new JsonHas(

--- a/src/test/java/com/artipie/docker/http/JsonContentTypeTest.java
+++ b/src/test/java/com/artipie/docker/http/JsonContentTypeTest.java
@@ -23,39 +23,22 @@
  */
 package com.artipie.docker.http;
 
-import com.artipie.http.headers.ContentType;
-import com.artipie.http.headers.Header;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Locale;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
 
 /**
- * Content-Type header with "application/json; charset=..." value.
+ * Test case for {@link JsonContentType}.
  *
  * @since 0.9
  */
-final class JsonContentType extends Header.Wrap {
+public final class JsonContentTypeTest {
 
-    /**
-     * Ctor.
-     */
-    protected JsonContentType() {
-        this(StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Ctor.
-     *
-     * @param charset Charset.
-     */
-    protected JsonContentType(final Charset charset) {
-        super(
-            new ContentType(
-                String.format(
-                    "application/json; charset=%s",
-                    charset.displayName().toLowerCase(Locale.getDefault())
-                )
-            )
+    @Test
+    void shouldHaveExpectedValue() {
+        MatcherAssert.assertThat(
+            new JsonContentType().getValue(),
+            new IsEqual<>("application/json; charset=utf-8")
         );
     }
 }


### PR DESCRIPTION
Closes #387 
Added `Content-Type` to error response and extracted `JsonContentType` for all JSON responses