### PR TITLE
#424 - Upload content and delete methods replaced with putTo

### DIFF
--- a/src/main/java/com/artipie/docker/Upload.java
+++ b/src/main/java/com/artipie/docker/Upload.java
@@ -23,7 +23,6 @@
  */
 package com.artipie.docker;
 
-import com.artipie.asto.Content;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletionStage;
 import org.reactivestreams.Publisher;
@@ -59,13 +58,6 @@ public interface Upload {
     CompletionStage<Long> append(Publisher<ByteBuffer> chunk);
 
     /**
-     * Get uploaded content.
-     *
-     * @return Content.
-     */
-    CompletionStage<Content> content();
-
-    /**
      * Get offset for the uploaded content.
      *
      * @return Offset.
@@ -73,9 +65,12 @@ public interface Upload {
     CompletionStage<Long> offset();
 
     /**
-     * Deletes upload blob data.
+     * Puts uploaded data to {@link Layers} creating a {@link Blob} with specified {@link Digest}.
+     * If upload data mismatch provided digest then error occurs and operation does not complete.
      *
-     * @return Completion or error signal.
+     * @param layers Target layers.
+     * @param digest Expected blob digest.
+     * @return Created blob.
      */
-    CompletionStage<Void> delete();
+    CompletionStage<Blob> putTo(Layers layers, Digest digest);
 }

--- a/src/main/java/com/artipie/docker/http/UploadEntity.java
+++ b/src/main/java/com/artipie/docker/http/UploadEntity.java
@@ -27,7 +27,6 @@ import com.artipie.docker.Digest;
 import com.artipie.docker.Docker;
 import com.artipie.docker.Repo;
 import com.artipie.docker.RepoName;
-import com.artipie.docker.asto.CheckedBlobSource;
 import com.artipie.docker.error.UploadUnknownError;
 import com.artipie.docker.misc.RqByRegex;
 import com.artipie.http.Connection;
@@ -254,14 +253,8 @@ public final class UploadEntity {
                 repo.uploads().get(uuid).thenApply(
                     found -> found.<Response>map(
                         upload -> new AsyncResponse(
-                            upload.content().thenCompose(
-                                content -> repo.layers()
-                                    .put(new CheckedBlobSource(content, request.digest()))
-                                    .thenCompose(
-                                        blob -> upload.delete().thenApply(
-                                            any -> new BlobCreatedResponse(name, request.digest())
-                                        )
-                                    )
+                            upload.putTo(repo.layers(), request.digest()).thenApply(
+                                any -> new BlobCreatedResponse(name, request.digest())
                             )
                         )
                     ).orElseGet(


### PR DESCRIPTION
Part of #424 
`Upload` `content` and `delete` methods replaced with `putTo`