### PR TITLE
Propagate content length of uploads

### DIFF
--- a/src/main/java/com/artipie/docker/Upload.java
+++ b/src/main/java/com/artipie/docker/Upload.java
@@ -23,9 +23,8 @@
  */
 package com.artipie.docker;
 
-import java.nio.ByteBuffer;
+import com.artipie.asto.Content;
 import java.util.concurrent.CompletionStage;
-import org.reactivestreams.Publisher;
 
 /**
  * Blob upload.
@@ -55,7 +54,7 @@ public interface Upload {
      * @param chunk Chunk of data.
      * @return Offset after appending chunk.
      */
-    CompletionStage<Long> append(Publisher<ByteBuffer> chunk);
+    CompletionStage<Long> append(Content chunk);
 
     /**
      * Get offset for the uploaded content.

--- a/src/main/java/com/artipie/docker/asto/AstoUpload.java
+++ b/src/main/java/com/artipie/docker/asto/AstoUpload.java
@@ -34,13 +34,11 @@ import com.artipie.docker.RepoName;
 import com.artipie.docker.Upload;
 import com.artipie.docker.error.InvalidDigestException;
 import com.artipie.docker.misc.DigestedFlowable;
-import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
-import org.reactivestreams.Publisher;
 
 /**
  * Asto implementation of {@link Upload}.
@@ -102,7 +100,7 @@ public final class AstoUpload implements Upload {
     }
 
     @Override
-    public CompletionStage<Long> append(final Publisher<ByteBuffer> chunk) {
+    public CompletionStage<Long> append(final Content chunk) {
         return this.chunks().thenCompose(
             chunks -> {
                 if (chunks.size() > 0) {
@@ -110,7 +108,7 @@ public final class AstoUpload implements Upload {
                 }
                 final Key tmp = new Key.From(this.root(), UUID.randomUUID().toString());
                 final DigestedFlowable data = new DigestedFlowable(chunk);
-                return this.storage.save(tmp, new Content.From(data)).thenCompose(
+                return this.storage.save(tmp, new Content.From(chunk.size(), data)).thenCompose(
                     nothing -> {
                         final Key key = this.chunk(data.digest());
                         return this.storage.move(tmp, key).thenApply(ignored -> key);

--- a/src/main/java/com/artipie/docker/http/UploadEntity.java
+++ b/src/main/java/com/artipie/docker/http/UploadEntity.java
@@ -40,6 +40,7 @@ import com.artipie.http.rq.RqParams;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithHeaders;
 import com.artipie.http.rs.RsWithStatus;
+import com.artipie.http.slice.ContentWithSize;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
@@ -198,7 +199,7 @@ public final class UploadEntity {
                 this.docker.repo(name).uploads().get(uuid).thenApply(
                     found -> found.<Response>map(
                         upload -> new AsyncResponse(
-                            upload.append(body).thenApply(
+                            upload.append(new ContentWithSize(body, headers)).thenApply(
                                 offset -> new StatusResponse(name, uuid, offset)
                             )
                         )

--- a/src/test/java/com/artipie/docker/http/CachingProxyITCase.java
+++ b/src/test/java/com/artipie/docker/http/CachingProxyITCase.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.condition.OS;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @DockerClientSupport
+@DisabledOnOs(OS.WINDOWS)
 final class CachingProxyITCase {
 
     /**

--- a/src/test/java/com/artipie/docker/http/UploadEntityPutTest.java
+++ b/src/test/java/com/artipie/docker/http/UploadEntityPutTest.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.docker.http;
 
+import com.artipie.asto.Content;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.docker.Digest;
@@ -39,7 +40,6 @@ import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rs.RsStatus;
 import io.reactivex.Flowable;
-import java.nio.ByteBuffer;
 import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -79,7 +79,7 @@ class UploadEntityPutTest {
         final Upload upload = this.docker.repo(new RepoName.Valid(name)).uploads()
             .start()
             .toCompletableFuture().join();
-        upload.append(Flowable.just(ByteBuffer.wrap("data".getBytes())))
+        upload.append(new Content.From("data".getBytes()))
             .toCompletableFuture().join();
         final String digest = String.format(
             "%s:%s",
@@ -116,8 +116,7 @@ class UploadEntityPutTest {
         final byte[] content = "something".getBytes();
         final Upload upload = this.docker.repo(new RepoName.Valid(name)).uploads().start()
             .toCompletableFuture().join();
-        upload.append(Flowable.just(ByteBuffer.wrap(content)))
-            .toCompletableFuture().join();
+        upload.append(new Content.From(content)).toCompletableFuture().join();
         MatcherAssert.assertThat(
             "Returns 400 status",
             this.slice,


### PR DESCRIPTION
Closes #447 - replaced `Publisher`s on upload with `Content` and
specify conent's length from HTTP headers received on upload.