### PR TITLE
Parse multi-value Accept header

### DIFF
--- a/src/main/java/com/artipie/docker/http/ManifestEntity.java
+++ b/src/main/java/com/artipie/docker/http/ManifestEntity.java
@@ -28,6 +28,7 @@ import com.artipie.docker.Docker;
 import com.artipie.docker.RepoName;
 import com.artipie.docker.error.ManifestError;
 import com.artipie.docker.manifest.Manifest;
+import com.artipie.docker.misc.AcceptHeader;
 import com.artipie.docker.misc.RqByRegex;
 import com.artipie.docker.ref.ManifestRef;
 import com.artipie.http.Response;
@@ -39,7 +40,6 @@ import com.artipie.http.auth.Permissions;
 import com.artipie.http.headers.ContentLength;
 import com.artipie.http.headers.ContentType;
 import com.artipie.http.headers.Location;
-import com.artipie.http.rq.RqHeaders;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.RsWithBody;
 import com.artipie.http.rs.RsWithHeaders;
@@ -47,6 +47,7 @@ import com.artipie.http.rs.RsWithStatus;
 import com.artipie.http.rs.StandardRs;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.reactivestreams.Publisher;
 
@@ -124,8 +125,8 @@ final class ManifestEntity {
          * @param headers Request headers
          * @return Accept headers
          */
-        private static RqHeaders acceptHeader(final Iterable<Map.Entry<String, String>> headers) {
-            return new RqHeaders(headers, "Accept");
+        private static Set<String> acceptHeader(final Iterable<Map.Entry<String, String>> headers) {
+            return new AcceptHeader(headers).values();
         }
     }
 

--- a/src/main/java/com/artipie/docker/misc/AcceptHeader.java
+++ b/src/main/java/com/artipie/docker/misc/AcceptHeader.java
@@ -31,8 +31,12 @@ import java.util.stream.Collectors;
 
 /**
  * The Accept request HTTP header values. For more details check
- * <a href="The Accept request HTTP header">documentation</a>.
+ * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept">documentation</a>.
  * @since 0.15
+ * @todo #499:30min Better support of Accept HTTP header: accept header values can have
+ *  quality weight and should be ordered according to this weight. Let's support this feature
+ *  and move this functionality to http repository. For more information check documentation:
+ *  https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
  */
 public final class AcceptHeader {
 

--- a/src/main/java/com/artipie/docker/misc/AcceptHeader.java
+++ b/src/main/java/com/artipie/docker/misc/AcceptHeader.java
@@ -1,0 +1,70 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.misc;
+
+import com.artipie.http.rq.RqHeaders;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The Accept request HTTP header values. For more details check
+ * <a href="The Accept request HTTP header">documentation</a>.
+ * @since 0.15
+ */
+public final class AcceptHeader {
+
+    /**
+     * Headers.
+     */
+    private final Iterable<Map.Entry<String, String>> headers;
+
+    /**
+     * Ctor.
+     * @param headers Headers
+     */
+    public AcceptHeader(final Iterable<Map.Entry<String, String>> headers) {
+        this.headers = headers;
+    }
+
+    /**
+     * Reads Accept header values.
+     * @return Values of the header
+     */
+    public Set<String> values() {
+        return new RqHeaders(this.headers, "Accept").stream().flatMap(
+            val -> Arrays.stream(val.split(", "))
+        ).map(
+            item -> {
+                final int index = item.indexOf(";");
+                String res = item;
+                if (index > 0) {
+                    res = res.substring(0, index);
+                }
+                return res;
+            }
+        ).collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/com/artipie/docker/http/ManifestEntityGetTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityGetTest.java
@@ -149,7 +149,8 @@ class ManifestEntityGetTest {
         Headers() {
             super(
                 new Headers.From(
-                    new Header("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+                    // @checkstyle LineLengthCheck (1 line)
+                    new Header("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/xml;q=0.9, image/webp")
                 )
             );
         }

--- a/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityHeadTest.java
@@ -135,7 +135,8 @@ class ManifestEntityHeadTest {
         Headers() {
             super(
                 new Headers.From(
-                    new Header("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+                    // @checkstyle LineLengthCheck (1 line)
+                    new Header("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/xml;q=0.9, image/*")
                 )
             );
         }

--- a/src/test/java/com/artipie/docker/misc/AcceptHeaderTest.java
+++ b/src/test/java/com/artipie/docker/misc/AcceptHeaderTest.java
@@ -1,0 +1,60 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.docker.misc;
+
+import com.artipie.http.Headers;
+import com.artipie.http.headers.Header;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link AcceptHeader}.
+ * @since 0.16
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class AcceptHeaderTest {
+
+    @Test
+    void parsesMultipleHeaders() {
+        MatcherAssert.assertThat(
+            new AcceptHeader(
+                // @checkstyle LineLengthCheck (5 lines)
+                new Headers.From(new Header("Accept", "text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8"), new Header("Accept", "abc/123, another"))
+            ).values(),
+            Matchers.containsInAnyOrder("text/html", "application/xhtml+xml", "application/xml", "image/webp", "*/*", "abc/123", "another")
+        );
+    }
+
+    @Test
+    void parsesSingle() {
+        MatcherAssert.assertThat(
+            new AcceptHeader(
+                new Headers.From(new Header("Accept", "application/json"))
+            ).values(),
+            Matchers.containsInAnyOrder("application/json")
+        );
+    }
+
+}


### PR DESCRIPTION
Fixes #449 
Added class and corresponding test to parse multi-value Accept header. Used this class in `ManifestEntity`.