### PR TITLE
Check manifest `mediaType` field on validation

### DIFF
--- a/src/main/java/com/artipie/docker/manifest/JsonManifest.java
+++ b/src/main/java/com/artipie/docker/manifest/JsonManifest.java
@@ -25,6 +25,7 @@ package com.artipie.docker.manifest;
 
 import com.artipie.asto.Content;
 import com.artipie.docker.Digest;
+import com.artipie.docker.error.InvalidManifestException;
 import java.io.ByteArrayInputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -70,7 +71,10 @@ public final class JsonManifest implements Manifest {
 
     @Override
     public String mediaType() {
-        return this.json().getString("mediaType");
+        return Optional.ofNullable(this.json().getString("mediaType", null))
+            .orElseThrow(
+                () -> new InvalidManifestException("Required field `mediaType` is absent")
+            );
     }
 
     @Override
@@ -93,7 +97,9 @@ public final class JsonManifest implements Manifest {
 
     @Override
     public Collection<Layer> layers() {
-        return this.json().getJsonArray("layers").getValuesAs(JsonValue::asJsonObject).stream()
+        return Optional.ofNullable(this.json().getJsonArray("layers")).orElseThrow(
+            () -> new InvalidManifestException("Required field `layers` is absent")
+        ).getValuesAs(JsonValue::asJsonObject).stream()
             .map(JsonLayer::new)
             .collect(Collectors.toList());
     }

--- a/src/test/java/com/artipie/docker/http/AuthTest.java
+++ b/src/test/java/com/artipie/docker/http/AuthTest.java
@@ -162,7 +162,7 @@ public final class AuthTest {
                 new Header("Content-Length", "0"),
                 new Header(
                     "Docker-Content-Digest",
-                    "sha256:02b9f91901050f814adfb19b1a8f5d599b07504998c2d665baa82e364322b566"
+                    "sha256:ef0ff2adcc3c944a63f7cafb386abc9a1d95528966085685ae9fab2a1c0bedbf"
                 )
             )
         );
@@ -179,7 +179,7 @@ public final class AuthTest {
                 new Header("Content-Length", "0"),
                 new Header(
                     "Docker-Content-Digest",
-                    "sha256:02b9f91901050f814adfb19b1a8f5d599b07504998c2d665baa82e364322b566"
+                    "sha256:ef0ff2adcc3c944a63f7cafb386abc9a1d95528966085685ae9fab2a1c0bedbf"
                 )
             )
         );
@@ -224,7 +224,7 @@ public final class AuthTest {
             .put(new TrustedBlobSource(content))
             .toCompletableFuture().join();
         final byte[] data = String.format(
-            "{\"config\":{\"digest\":\"%s\"},\"layers\":[]}",
+            "{\"config\":{\"digest\":\"%s\"},\"layers\":[],\"mediaType\":\"my-type\"}",
             config.digest().string()
         ).getBytes();
         return Flowable.just(ByteBuffer.wrap(data));

--- a/src/test/java/com/artipie/docker/http/ManifestEntityPutTest.java
+++ b/src/test/java/com/artipie/docker/http/ManifestEntityPutTest.java
@@ -82,7 +82,7 @@ class ManifestEntityPutTest {
                 new Header("Content-Length", "0"),
                 new Header(
                     "Docker-Content-Digest",
-                    "sha256:02b9f91901050f814adfb19b1a8f5d599b07504998c2d665baa82e364322b566"
+                    "sha256:ef0ff2adcc3c944a63f7cafb386abc9a1d95528966085685ae9fab2a1c0bedbf"
                 )
             )
         );
@@ -93,7 +93,7 @@ class ManifestEntityPutTest {
         final String digest = String.format(
             "%s:%s",
             "sha256",
-            "02b9f91901050f814adfb19b1a8f5d599b07504998c2d665baa82e364322b566"
+            "ef0ff2adcc3c944a63f7cafb386abc9a1d95528966085685ae9fab2a1c0bedbf"
         );
         final String path = String.format("/v2/my-alpine/manifests/%s", digest);
         MatcherAssert.assertThat(
@@ -122,7 +122,7 @@ class ManifestEntityPutTest {
             .put(new TrustedBlobSource(content))
             .toCompletableFuture().join();
         final byte[] data = String.format(
-            "{\"config\":{\"digest\":\"%s\"},\"layers\":[]}",
+            "{\"config\":{\"digest\":\"%s\"},\"layers\":[],\"mediaType\":\"my-type\"}",
             config.digest().string()
         ).getBytes();
         return Flowable.just(ByteBuffer.wrap(data));

--- a/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
+++ b/src/test/java/com/artipie/docker/manifest/JsonManifestTest.java
@@ -25,6 +25,7 @@ package com.artipie.docker.manifest;
 
 import com.artipie.asto.ext.PublisherAs;
 import com.artipie.docker.Digest;
+import com.artipie.docker.error.InvalidManifestException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,7 +45,7 @@ import org.junit.jupiter.api.Test;
  * @since 0.2
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 class JsonManifestTest {
 
     @Test
@@ -56,6 +57,18 @@ class JsonManifestTest {
         MatcherAssert.assertThat(
             manifest.mediaType(),
             new IsEqual<>("something")
+        );
+    }
+
+    @Test
+    void shouldFailWhenMediaTypeIsAbsent() {
+        final JsonManifest manifest = new JsonManifest(
+            new Digest.Sha256("123"),
+            "{\"abc\":\"123\"}".getBytes()
+        );
+        Assertions.assertThrows(
+            InvalidManifestException.class,
+            manifest::mediaType
         );
     }
 
@@ -155,6 +168,18 @@ class JsonManifestTest {
                 .flatMap(layer -> layer.urls().stream())
                 .collect(Collectors.toList()),
             new IsIterableContaining<>(new IsEqual<>(new URL(url)))
+        );
+    }
+
+    @Test
+    void shouldFailWhenLayersAreAbsent() {
+        final JsonManifest manifest = new JsonManifest(
+            new Digest.Sha256("123"),
+            "{\"any\":\"value\"}".getBytes()
+        );
+        Assertions.assertThrows(
+            InvalidManifestException.class,
+            manifest::layers
         );
     }
 


### PR DESCRIPTION
Closes #446 
`mediaType` field in manifest json is required. I've added corresponding check in validation process on upload, corrected `JsonManifest` to throw `InvalidManifestException` when required fields are absent, fixed tests where necessary.